### PR TITLE
Add `skill` CLI subcommand to list cached and installed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ go test -tags=integration ./...
 - `striatum install <reference>` — install into Cursor/Claude skills directories
 - `striatum uninstall <name>` — remove an installed skill
 - `striatum inspect <reference>` — show remote artifact metadata
+- `striatum skill list` — list skills in local cache; use `--installed` to list installed skills (optional `--target cursor|claude`)
 
 ### Usage examples
 
@@ -43,6 +44,8 @@ striatum pull localhost:5000/skills/my-skill:1.0.0
 striatum install --target cursor localhost:5000/skills/my-skill:1.0.0
 striatum uninstall --target cursor my-skill
 striatum inspect localhost:5000/skills/my-skill:1.0.0
+striatum skill list
+striatum skill list --installed --target cursor
 ```
 
 See [docs/MVP.md](docs/MVP.md) for the full specification and [docs/demo.md](docs/demo.md) for a full-flow demo (pack, push, pull, install, uninstall).

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var subcommands = []string{"init", "validate", "pack", "push", "pull", "install", "uninstall", "inspect"}
+var subcommands = []string{"init", "validate", "pack", "push", "pull", "install", "uninstall", "inspect", "skill"}
 
 func TestSubcommands_Registered(t *testing.T) {
 	root := NewRootCommand()
@@ -72,6 +72,16 @@ func TestCommandsRequiringArg_AcceptOneArg(t *testing.T) {
 		if err != nil && strings.Contains(err.Error(), "accepts ") {
 			t.Errorf("striatum %s: unexpected arg-count error: %v", name, err)
 		}
+	}
+}
+
+func TestSkillList_HelpExitsZero(t *testing.T) {
+	root := NewRootCommand()
+	out := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Errorf("striatum skill list --help: err = %v", err)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -26,6 +26,7 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(newInstallCmd())
 	cmd.AddCommand(newUninstallCmd())
 	cmd.AddCommand(newInspectCmd())
+	cmd.AddCommand(newSkillCmd())
 	return cmd
 }
 

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -1,0 +1,14 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newSkillCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "skill",
+		Short: "Manage skills",
+	}
+	cmd.AddCommand(newSkillListCmd())
+	return cmd
+}

--- a/internal/cli/skill_list.go
+++ b/internal/cli/skill_list.go
@@ -29,6 +29,9 @@ func newSkillListCmd() *cobra.Command {
 }
 
 func runSkillList(cmd *cobra.Command, installed bool, target string) error {
+	if !installed && target != "" {
+		return fmt.Errorf("--target is only valid with --installed")
+	}
 	out := cmd.OutOrStdout()
 	if installed {
 		if target != "" && target != "cursor" && target != "claude" {

--- a/internal/cli/skill_list.go
+++ b/internal/cli/skill_list.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/hbelmiro/striatum/pkg/installer"
+	"github.com/spf13/cobra"
+)
+
+func newSkillListCmd() *cobra.Command {
+	var installed bool
+	var target string
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List skills in cache or installed",
+		Long:    "List skills in the local cache. Use --installed to list installed skills (optionally filter by --target).",
+		Example: "  striatum skill list\n  striatum skill list --installed --target cursor",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runSkillList(cmd, installed, target)
+		},
+	}
+	cmd.Flags().BoolVar(&installed, "installed", false, "List installed skills instead of cache")
+	cmd.Flags().StringVar(&target, "target", "", "Filter installed list by target (cursor or claude); only with --installed")
+	return cmd
+}
+
+func runSkillList(cmd *cobra.Command, installed bool, target string) error {
+	out := cmd.OutOrStdout()
+	if installed {
+		if target != "" && target != "cursor" && target != "claude" {
+			return fmt.Errorf("--target must be cursor or claude, got %q", target)
+		}
+		entries, err := installer.LoadInstalled()
+		if err != nil {
+			return fmt.Errorf("load installed: %w", err)
+		}
+		if target != "" {
+			filtered := entries[:0]
+			for _, e := range entries {
+				if e.Target == target {
+					filtered = append(filtered, e)
+				}
+			}
+			entries = filtered
+		}
+		if len(entries) == 0 {
+			_, _ = fmt.Fprintln(out, "No installed skills.")
+			return nil
+		}
+		writeAlignedTable(out, []string{"NAME", "VERSION", "TARGET", "INSTALLED_WITH"}, func(w io.Writer) {
+			for _, e := range entries {
+				with := e.InstalledWith
+				if with == "" {
+					with = "-"
+				}
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", e.Skill, e.Version, e.Target, with)
+			}
+		})
+		return nil
+	}
+	skills, err := installer.ListCachedSkills()
+	if err != nil {
+		return fmt.Errorf("list cache: %w", err)
+	}
+	if len(skills) == 0 {
+		_, _ = fmt.Fprintln(out, "No skills in cache.")
+		return nil
+	}
+	writeAlignedTable(out, []string{"NAME", "VERSION", "DESCRIPTION"}, func(w io.Writer) {
+		for _, s := range skills {
+			desc := s.Description
+			if desc == "" {
+				desc = "-"
+			}
+			desc = strings.ReplaceAll(desc, "\n", " ")
+			_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, s.Version, desc)
+		}
+	})
+	return nil
+}
+
+// writeAlignedTable writes a header row and then body rows to out using tabwriter for column alignment.
+func writeAlignedTable(out io.Writer, headers []string, writeRows func(io.Writer)) {
+	tw := tabwriter.NewWriter(out, 2, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, strings.Join(headers, "\t"))
+	writeRows(tw)
+	_ = tw.Flush()
+}

--- a/internal/cli/skill_list_test.go
+++ b/internal/cli/skill_list_test.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hbelmiro/striatum/pkg/artifact"
+	"github.com/hbelmiro/striatum/pkg/installer"
+)
+
+func TestSkillList_EmptyCache_ExitsZeroAndShowsNoSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	root := NewRootCommand()
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("skill list: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "No skills") {
+		t.Errorf("output should contain 'No skills'; got %q", got)
+	}
+}
+
+func TestSkillList_OneCachedSkill_OutputContainsNameAndVersion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	cacheDir := installer.CacheDir("foo", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifactForList(t, cacheDir, &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "foo", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	})
+	root := NewRootCommand()
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("skill list: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "foo") || !strings.Contains(got, "1.0.0") {
+		t.Errorf("output should contain name and version; got %q", got)
+	}
+}
+
+func TestSkillList_Installed_Empty_ExitsZero(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	// No installed.yaml or empty
+	root := NewRootCommand()
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list", "--installed"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("skill list --installed: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "No ") {
+		t.Errorf("output should indicate no installed skills (e.g. 'No installed skills'); got %q", got)
+	}
+}
+
+func TestSkillList_Installed_WithEntries_ShowsTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	if err := installer.SaveInstalled([]installer.InstalledEntry{
+		{Skill: "bar", Version: "2.0.0", Registry: "reg", Target: "cursor", Status: "ok", UpdatedAt: "2026-01-01T00:00:00Z"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	root := NewRootCommand()
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list", "--installed"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("skill list --installed: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "bar") || !strings.Contains(got, "2.0.0") || !strings.Contains(got, "cursor") {
+		t.Errorf("output should contain skill, version, target; got %q", got)
+	}
+}
+
+func TestSkillList_Installed_CorruptInstalledYAML_ReturnsError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	installedPath := installer.InstalledPath()
+	if err := os.MkdirAll(filepath.Dir(installedPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(installedPath, []byte("invalid: [[["), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "list", "--installed"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("skill list --installed with corrupt installed.yaml: expected error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "load installed") {
+		t.Errorf("error should mention load installed: %v", err)
+	}
+}
+
+func TestSkillList_Installed_WithTarget_Filters(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	if err := installer.SaveInstalled([]installer.InstalledEntry{
+		{Skill: "only-cursor", Version: "1.0.0", Registry: "r", Target: "cursor", Status: "ok", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{Skill: "only-claude", Version: "1.0.0", Registry: "r", Target: "claude", Status: "ok", UpdatedAt: "2026-01-01T00:00:00Z"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	root := NewRootCommand()
+	out := &strings.Builder{}
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "list", "--installed", "--target", "cursor"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("skill list --installed --target cursor: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "only-cursor") {
+		t.Errorf("output should contain only-cursor; got %q", got)
+	}
+	if strings.Contains(got, "only-claude") {
+		t.Errorf("output should not contain only-claude when filtering by cursor; got %q", got)
+	}
+}
+
+func writeArtifactForList(t *testing.T, dir string, m *artifact.Manifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/skill_list_test.go
+++ b/internal/cli/skill_list_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/hbelmiro/striatum/pkg/installer"
 )
 
+func TestSkillList_TargetWithoutInstalled_ReturnsError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "list", "--target", "cursor"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("skill list --target cursor without --installed: expected error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "only valid with --installed") {
+		t.Errorf("error should mention --target only valid with --installed: %v", err)
+	}
+}
+
 func TestSkillList_EmptyCache_ExitsZeroAndShowsNoSkills(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STRIATUM_HOME", home)

--- a/pkg/installer/list.go
+++ b/pkg/installer/list.go
@@ -1,0 +1,66 @@
+package installer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/hbelmiro/striatum/pkg/artifact"
+)
+
+// CachedSkill describes a skill present in the local cache.
+type CachedSkill struct {
+	Name        string
+	Version     string
+	Description string
+}
+
+// ListCachedSkills returns all skills in the cache (directories name@version with artifact.json).
+// Returns empty slice and nil error when cache dir is missing or empty.
+func ListCachedSkills() ([]CachedSkill, error) {
+	cacheRoot := filepath.Join(CacheRoot(), cacheDirName)
+	entries, err := os.ReadDir(cacheRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read cache dir %s: %w", cacheRoot, err)
+	}
+	var result []CachedSkill
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		i := strings.LastIndex(name, "@")
+		if i < 0 {
+			continue
+		}
+		skillName, version := name[:i], name[i+1:]
+		if version == "" {
+			continue
+		}
+		dirPath := filepath.Join(cacheRoot, name)
+		manifestPath := filepath.Join(dirPath, "artifact.json")
+		if _, err := os.Stat(manifestPath); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("stat manifest %s: %w", manifestPath, err)
+		}
+		desc := ""
+		if m, err := artifact.Load(manifestPath); err == nil {
+			desc = m.Metadata.Description
+		}
+		result = append(result, CachedSkill{Name: skillName, Version: version, Description: desc})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Name != result[j].Name {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Version < result[j].Version
+	})
+	return result, nil
+}

--- a/pkg/installer/list.go
+++ b/pkg/installer/list.go
@@ -18,13 +18,13 @@ type CachedSkill struct {
 }
 
 // ListCachedSkills returns all skills in the cache (directories name@version with artifact.json).
-// Returns empty slice and nil error when cache dir is missing or empty.
+// Returns a non-nil empty slice and nil error when cache dir is missing or empty.
 func ListCachedSkills() ([]CachedSkill, error) {
 	cacheRoot := filepath.Join(CacheRoot(), cacheDirName)
 	entries, err := os.ReadDir(cacheRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return []CachedSkill{}, nil
 		}
 		return nil, fmt.Errorf("read cache dir %s: %w", cacheRoot, err)
 	}
@@ -39,7 +39,7 @@ func ListCachedSkills() ([]CachedSkill, error) {
 			continue
 		}
 		skillName, version := name[:i], name[i+1:]
-		if version == "" {
+		if strings.TrimSpace(skillName) == "" || version == "" {
 			continue
 		}
 		dirPath := filepath.Join(cacheRoot, name)
@@ -50,11 +50,11 @@ func ListCachedSkills() ([]CachedSkill, error) {
 			}
 			return nil, fmt.Errorf("stat manifest %s: %w", manifestPath, err)
 		}
-		desc := ""
-		if m, err := artifact.Load(manifestPath); err == nil {
-			desc = m.Metadata.Description
+		m, err := artifact.Load(manifestPath)
+		if err != nil {
+			continue
 		}
-		result = append(result, CachedSkill{Name: skillName, Version: version, Description: desc})
+		result = append(result, CachedSkill{Name: skillName, Version: version, Description: m.Metadata.Description})
 	}
 	sort.Slice(result, func(i, j int) bool {
 		if result[i].Name != result[j].Name {
@@ -62,5 +62,8 @@ func ListCachedSkills() ([]CachedSkill, error) {
 		}
 		return result[i].Version < result[j].Version
 	})
+	if result == nil {
+		result = []CachedSkill{}
+	}
 	return result, nil
 }

--- a/pkg/installer/list_test.go
+++ b/pkg/installer/list_test.go
@@ -1,0 +1,175 @@
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hbelmiro/striatum/pkg/artifact"
+)
+
+func TestListCachedSkills_EmptyOrMissingCacheDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	// No cache/ dir at all
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (missing cache dir)", len(got))
+	}
+}
+
+func TestListCachedSkills_EmptyCacheDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheRoot := filepath.Join(dir, cacheDirName)
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (empty cache)", len(got))
+	}
+}
+
+func TestListCachedSkills_OneValidEntry(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheDir := CacheDir("foo", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifactManifest(t, cacheDir, &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "foo", Version: "1.0.0", Description: "A test skill"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	})
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Name != "foo" || got[0].Version != "1.0.0" {
+		t.Errorf("got[0] = %+v, want Name=foo Version=1.0.0", got[0])
+	}
+	if got[0].Description != "A test skill" {
+		t.Errorf("got[0].Description = %q, want %q", got[0].Description, "A test skill")
+	}
+}
+
+func TestListCachedSkills_MultipleEntriesSorted(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	for _, name := range []string{"b", "a"} {
+		cacheDir := CacheDir(name, "1.0.0")
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeArtifactManifest(t, cacheDir, &artifact.Manifest{
+			APIVersion: "striatum.dev/v1alpha1",
+			Kind:       "Skill",
+			Metadata:   artifact.Metadata{Name: name, Version: "1.0.0"},
+			Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+		})
+	}
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("want sorted by name: got %q, %q", got[0].Name, got[1].Name)
+	}
+}
+
+func TestListCachedSkills_SkipsDirWithoutArtifactJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheDir := CacheDir("partial", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// No artifact.json
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (dir without artifact.json skipped)", len(got))
+	}
+}
+
+func TestListCachedSkills_SkipsDirNameWithoutAt(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheRoot := filepath.Join(dir, cacheDirName)
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	invalidDir := filepath.Join(cacheRoot, "invalid")
+	if err := os.MkdirAll(invalidDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(invalidDir, "artifact.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (dir name without @ skipped)", len(got))
+	}
+}
+
+func TestListCachedSkills_NameWithMultipleAt_SplitOnLast(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	// Dir name "a@b@1.0.0" -> name "a@b", version "1.0.0"
+	cacheRoot := filepath.Join(dir, cacheDirName)
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	multiAtDir := filepath.Join(cacheRoot, "a@b@1.0.0")
+	if err := os.MkdirAll(multiAtDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifactManifest(t, multiAtDir, &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "a@b", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	})
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[0].Name != "a@b" || got[0].Version != "1.0.0" {
+		t.Errorf("got[0] = Name=%q Version=%q, want a@b and 1.0.0", got[0].Name, got[0].Version)
+	}
+}
+
+func writeArtifactManifest(t *testing.T, dir string, m *artifact.Manifest) {
+	t.Helper()
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/installer/list_test.go
+++ b/pkg/installer/list_test.go
@@ -93,6 +93,25 @@ func TestListCachedSkills_MultipleEntriesSorted(t *testing.T) {
 	}
 }
 
+func TestListCachedSkills_SkipsCorruptManifest(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheDir := CacheDir("corrupt", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "artifact.json"), []byte("not valid json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (dir with corrupt artifact.json skipped)", len(got))
+	}
+}
+
 func TestListCachedSkills_SkipsDirWithoutArtifactJSON(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("STRIATUM_HOME", dir)
@@ -130,6 +149,32 @@ func TestListCachedSkills_SkipsDirNameWithoutAt(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("len(got) = %d, want 0 (dir name without @ skipped)", len(got))
+	}
+}
+
+func TestListCachedSkills_SkipsEmptySkillName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheRoot := filepath.Join(dir, cacheDirName)
+	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	emptyNameDir := filepath.Join(cacheRoot, "@1.0.0")
+	if err := os.MkdirAll(emptyNameDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeArtifactManifest(t, emptyNameDir, &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	})
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (dir @1.0.0 has empty skill name, skipped)", len(got))
 	}
 }
 


### PR DESCRIPTION
Introduces the `striatum skill list` command for displaying skills in the local cache or installed skills with optional filters. Updates core functionality, tests, and documentation accordingly.