### PR TITLE
Refactor CLI for `skill install` and `skill uninstall`; improve `init…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,12 +35,12 @@ go test -tags=integration ./...
 
 | Command | Purpose |
 | ------- | ------- |
-| `striatum init` | Scaffold `artifact.json` |
+| `striatum init` | Scaffold `artifact.json` (requires `--name`, `--kind`, `--entrypoint`) |
 | `striatum validate` | Validate artifact (optional `--check-deps`) |
 | `striatum pack` | Bundle into local OCI Image Layout |
 | `striatum push <ref>` | Push to OCI registry |
 | `striatum pull <ref>` | Pull artifact and deps |
-| `striatum install <ref>` | Install into Cursor/Claude skills dirs |
-| `striatum uninstall <name>` | Remove installed skill |
 | `striatum inspect <ref>` | Show remote artifact metadata |
+| `striatum skill install <ref>` | Install skill into Cursor/Claude skills dirs |
+| `striatum skill uninstall <name>` | Remove installed skill |
 | `striatum skill list` | List cached skills; use `--installed --target cursor` or `--target claude` for installed |

--- a/README.md
+++ b/README.md
@@ -22,27 +22,27 @@ go test -tags=integration ./...
 
 ## Commands
 
-- `striatum init` — scaffold an `artifact.json`
+- `striatum init` — scaffold an `artifact.json` (requires `--name`, `--kind`, `--entrypoint`)
 - `striatum validate` — validate local artifact and optionally check dependencies
 - `striatum pack` — bundle artifact into a local OCI Image Layout
 - `striatum push <reference>` — push to an OCI registry
 - `striatum pull <reference>` — download artifact and dependencies
-- `striatum install <reference>` — install into Cursor/Claude skills directories
-- `striatum uninstall <name>` — remove an installed skill
 - `striatum inspect <reference>` — show remote artifact metadata
+- `striatum skill install <reference>` — install a skill into Cursor/Claude skills directories
+- `striatum skill uninstall <name>` — remove an installed skill
 - `striatum skill list` — list skills in local cache; use `--installed` to list installed skills (optional `--target cursor|claude`)
 
 ### Usage examples
 
 ```bash
-striatum init --name my-skill
+striatum init --name my-skill --kind Skill --entrypoint SKILL.md
 striatum validate
 striatum validate --check-deps --registry localhost:5000/skills
 striatum pack
 striatum push localhost:5000/skills/my-skill:1.0.0
 striatum pull localhost:5000/skills/my-skill:1.0.0
-striatum install --target cursor localhost:5000/skills/my-skill:1.0.0
-striatum uninstall --target cursor my-skill
+striatum skill install --target cursor localhost:5000/skills/my-skill:1.0.0
+striatum skill uninstall --target cursor my-skill
 striatum inspect localhost:5000/skills/my-skill:1.0.0
 striatum skill list
 striatum skill list --installed --target cursor

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -5,8 +5,8 @@ This demo runs the full Striatum flow using **fictitious** artifacts with depend
 1. **Pack** — bundle each artifact into an OCI layout
 2. **Push** — push to a local OCI registry
 3. **Pull** — download the root artifact and its transitive dependencies
-4. **Install** — copy into the Cursor skills directory
-5. **Uninstall** — remove the skill and orphaned dependencies
+4. **Skill Install** — copy into the Cursor skills directory
+5. **Skill Uninstall** — remove the skill and orphaned dependencies
 
 The demo artifacts live in the `demo/` directory:
 
@@ -44,10 +44,10 @@ sleep 2
 (cd demo/example-helper-b && ../../striatum pack && ../../striatum push localhost:5000/demo/example-helper-b:1.0.0)
 (cd demo/example-skill  && ../../striatum pack && ../../striatum push localhost:5000/demo/example-skill:1.0.0)
 
-# Pull, install, uninstall
+# Pull, skill install, skill uninstall
 ./striatum pull localhost:5000/demo/example-skill:1.0.0 -o ./demo-out
-./striatum install --target cursor localhost:5000/demo/example-skill:1.0.0
-./striatum uninstall --target cursor example-skill
+./striatum skill install --target cursor localhost:5000/demo/example-skill:1.0.0
+./striatum skill uninstall --target cursor example-skill
 
 # Stop registry
 docker rm -f striatum-demo

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var subcommands = []string{"init", "validate", "pack", "push", "pull", "install", "uninstall", "inspect", "skill"}
+var subcommands = []string{"init", "validate", "pack", "push", "pull", "inspect", "skill"}
 
 func TestSubcommands_Registered(t *testing.T) {
 	root := NewRootCommand()
@@ -33,44 +33,58 @@ func TestSubcommand_HelpExitsZero(t *testing.T) {
 	}
 }
 
-var commandsRequiringArg = []string{"install", "uninstall"}
+var skillSubcommandsRequiringArg = []struct {
+	args    []string
+	desc    string
+	tooMany []string
+}{
+	{
+		args:    []string{"skill", "install"},
+		desc:    "skill install",
+		tooMany: []string{"skill", "install", "first", "second"},
+	},
+	{
+		args:    []string{"skill", "uninstall"},
+		desc:    "skill uninstall",
+		tooMany: []string{"skill", "uninstall", "first", "second"},
+	},
+}
 
-func TestCommandsRequiringArg_ErrorWithoutArg(t *testing.T) {
-	for _, name := range commandsRequiringArg {
+func TestSkillSubcommands_ErrorWithoutArg(t *testing.T) {
+	for _, tc := range skillSubcommandsRequiringArg {
 		root := NewRootCommand()
-		root.SetArgs([]string{name})
+		root.SetArgs(tc.args)
 		err := root.Execute()
 		if err == nil {
-			t.Errorf("striatum %s (no arg): expected error, got nil", name)
+			t.Errorf("striatum %s (no arg): expected error, got nil", tc.desc)
 		}
 	}
 }
 
-func TestCommandsRequiringArg_ErrorWithTooManyArgs(t *testing.T) {
-	for _, name := range commandsRequiringArg {
+func TestSkillSubcommands_ErrorWithTooManyArgs(t *testing.T) {
+	for _, tc := range skillSubcommandsRequiringArg {
 		root := NewRootCommand()
-		root.SetArgs([]string{name, "first", "second"})
+		root.SetArgs(tc.tooMany)
 		err := root.Execute()
 		if err == nil {
-			t.Errorf("striatum %s (two args): expected error, got nil", name)
+			t.Errorf("striatum %s (two args): expected error, got nil", tc.desc)
 		}
 	}
 }
 
-func TestCommandsRequiringArg_AcceptOneArg(t *testing.T) {
+func TestSkillSubcommands_AcceptOneArg(t *testing.T) {
 	argsByCmd := map[string][]string{
-		"install":   {"install", "some-ref-or-name", "--target", "cursor"},
-		"uninstall": {"uninstall", "some-name", "--target", "cursor"},
+		"skill install":   {"skill", "install", "some-ref-or-name", "--target", "cursor"},
+		"skill uninstall": {"skill", "uninstall", "some-name", "--target", "cursor"},
 	}
-	for _, name := range commandsRequiringArg {
+	for _, tc := range skillSubcommandsRequiringArg {
 		root := NewRootCommand()
 		out := &bytes.Buffer{}
 		root.SetOut(out)
-		root.SetArgs(argsByCmd[name])
+		root.SetArgs(argsByCmd[tc.desc])
 		err := root.Execute()
-		// Should not fail with "accepts 1 arg(s)" (wrong arg count); other errors (e.g. invalid ref, not installed) are ok
 		if err != nil && strings.Contains(err.Error(), "accepts ") {
-			t.Errorf("striatum %s: unexpected arg-count error: %v", name, err)
+			t.Errorf("striatum %s: unexpected arg-count error: %v", tc.desc, err)
 		}
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -19,17 +19,24 @@ func newInitCmd() *cobra.Command {
 		Long:    "Creates an artifact.json in the current directory with the given name, version, and kind. Requires --name, --kind, and --entrypoint.",
 		Example: "  striatum init --name my-skill --kind Skill --entrypoint SKILL.md",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name = strings.TrimSpace(name)
+			kind = strings.TrimSpace(kind)
+			entrypoint = strings.TrimSpace(entrypoint)
 			if name == "" {
 				return fmt.Errorf("artifact name is required (use --name)")
 			}
-			if strings.TrimSpace(kind) == "" {
+			if kind == "" {
 				return fmt.Errorf("artifact kind is required (use --kind)")
 			}
 			if !artifact.IsSupportedKind(kind) {
-				return fmt.Errorf("unsupported kind %q", kind)
+				return fmt.Errorf("unsupported kind %q; supported: %s", kind, artifact.SupportedKindsList())
 			}
-			if strings.TrimSpace(entrypoint) == "" {
+			if entrypoint == "" {
 				return fmt.Errorf("entrypoint is required (use --entrypoint)")
+			}
+			version = strings.TrimSpace(version)
+			if version == "" {
+				version = "0.1.0"
 			}
 			wd, err := os.Getwd()
 			if err != nil {
@@ -40,6 +47,9 @@ func newInitCmd() *cobra.Command {
 				Kind:       kind,
 				Metadata:   artifact.Metadata{Name: name, Version: version},
 				Spec:       artifact.Spec{Entrypoint: entrypoint, Files: []string{entrypoint}},
+			}
+			if err := artifact.Validate(m); err != nil {
+				return fmt.Errorf("invalid manifest: %w", err)
 			}
 			path := filepath.Join(wd, "artifact.json")
 			data, err := json.MarshalIndent(m, "", "  ")

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -16,14 +16,20 @@ func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "init",
 		Short:   "Scaffold an artifact.json in the current directory",
-		Long:    "Creates an artifact.json in the current directory with the given name, version, and kind. The entrypoint file (default SKILL.md) is added to spec.files.",
-		Example: "  striatum init --name my-skill",
+		Long:    "Creates an artifact.json in the current directory with the given name, version, and kind. Requires --name, --kind, and --entrypoint.",
+		Example: "  striatum init --name my-skill --kind Skill --entrypoint SKILL.md",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if name == "" {
 				return fmt.Errorf("artifact name is required (use --name)")
 			}
+			if strings.TrimSpace(kind) == "" {
+				return fmt.Errorf("artifact kind is required (use --kind)")
+			}
+			if !artifact.IsSupportedKind(kind) {
+				return fmt.Errorf("unsupported kind %q", kind)
+			}
 			if strings.TrimSpace(entrypoint) == "" {
-				return fmt.Errorf("entrypoint must be non-empty")
+				return fmt.Errorf("entrypoint is required (use --entrypoint)")
 			}
 			wd, err := os.Getwd()
 			if err != nil {
@@ -49,8 +55,10 @@ func newInitCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Artifact name (required)")
 	cmd.Flags().StringVar(&version, "version", "0.1.0", "Artifact version")
-	cmd.Flags().StringVar(&kind, "kind", "Skill", "Artifact kind")
-	cmd.Flags().StringVar(&entrypoint, "entrypoint", "SKILL.md", "Entrypoint file (must be in spec.files)")
+	cmd.Flags().StringVar(&kind, "kind", "", "Artifact kind (required, e.g. Skill)")
+	cmd.Flags().StringVar(&entrypoint, "entrypoint", "", "Entrypoint file (required)")
 	_ = cmd.MarkFlagRequired("name")
+	_ = cmd.MarkFlagRequired("kind")
+	_ = cmd.MarkFlagRequired("entrypoint")
 	return cmd
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -13,7 +13,7 @@ func TestInit_CreatesArtifactJSON(t *testing.T) {
 	t.Chdir(dir)
 
 	root := NewRootCommand()
-	root.SetArgs([]string{"init", "--name", "my-skill"})
+	root.SetArgs([]string{"init", "--name", "my-skill", "--kind", "Skill", "--entrypoint", "SKILL.md"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestInit_WithVersionAndKind(t *testing.T) {
 	t.Chdir(dir)
 
 	root := NewRootCommand()
-	root.SetArgs([]string{"init", "--name", "x", "--version", "2.0.0", "--kind", "Skill"})
+	root.SetArgs([]string{"init", "--name", "x", "--version", "2.0.0", "--kind", "Skill", "--entrypoint", "SKILL.md"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -69,10 +69,43 @@ func TestInit_RequiresName(t *testing.T) {
 	t.Chdir(t.TempDir())
 
 	root := NewRootCommand()
-	root.SetArgs([]string{"init"})
+	root.SetArgs([]string{"init", "--kind", "Skill", "--entrypoint", "SKILL.md"})
 	err := root.Execute()
 	if err == nil {
 		t.Error("init without --name: expected error, got nil")
+	}
+}
+
+func TestInit_RequiresKind(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"init", "--name", "x", "--entrypoint", "SKILL.md"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("init without --kind: expected error, got nil")
+	}
+}
+
+func TestInit_RequiresEntrypoint(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"init", "--name", "x", "--kind", "Skill"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("init without --entrypoint: expected error, got nil")
+	}
+}
+
+func TestInit_RejectsUnsupportedKind(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"init", "--name", "x", "--kind", "Unknown", "--entrypoint", "main.md"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("init with unsupported kind: expected error, got nil")
 	}
 }
 
@@ -81,7 +114,7 @@ func TestInit_CustomEntrypoint(t *testing.T) {
 	t.Chdir(dir)
 
 	root := NewRootCommand()
-	root.SetArgs([]string{"init", "--name", "x", "--entrypoint", "OTHER.md"})
+	root.SetArgs([]string{"init", "--name", "x", "--kind", "Skill", "--entrypoint", "OTHER.md"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("init: %v", err)
 	}
@@ -107,7 +140,7 @@ func TestInit_OverwritesExistingArtifactJSON(t *testing.T) {
 	t.Chdir(dir)
 
 	root := NewRootCommand()
-	root.SetArgs([]string{"init", "--name", "new-skill", "--version", "1.0.0"})
+	root.SetArgs([]string{"init", "--name", "new-skill", "--version", "1.0.0", "--kind", "Skill", "--entrypoint", "SKILL.md"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("init: %v", err)
 	}

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -22,9 +22,9 @@ func newInstallCmd() *cobra.Command {
 	var force, reinstallAll bool
 	cmd := &cobra.Command{
 		Use:     "install",
-		Short:   "Pull and install an artifact into AI coding agent skills directories",
-		Long:    "Resolves the artifact and dependencies, copies them to the install target (Cursor or Claude skills dir). Requires --target (cursor or claude). Use --project for project-level install.",
-		Example: "  striatum install --target cursor localhost:5000/skills/my-skill:1.0.0",
+		Short:   "Pull and install a skill into AI coding agent skills directories",
+		Long:    "Resolves the skill artifact and dependencies, copies them to the install target (Cursor or Claude skills dir). Requires --target (cursor or claude). Use --project for project-level install.",
+		Example: "  striatum skill install --target cursor localhost:5000/skills/my-skill:1.0.0",
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if reinstallAll {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestInstall_MissingTargetErrors(t *testing.T) {
 	root := NewRootCommand()
-	root.SetArgs([]string{"install", "localhost:5000/skills/foo:1.0.0"})
+	root.SetArgs([]string{"skill", "install", "localhost:5000/skills/foo:1.0.0"})
 	err := root.Execute()
 	if err == nil {
 		t.Error("install without --target: expected error")
@@ -26,7 +26,7 @@ func TestInstall_MissingTargetErrors(t *testing.T) {
 
 func TestInstall_InvalidTargetErrors(t *testing.T) {
 	root := NewRootCommand()
-	root.SetArgs([]string{"install", "--target", "all", "localhost:5000/skills/foo:1.0.0"})
+	root.SetArgs([]string{"skill", "install", "--target", "all", "localhost:5000/skills/foo:1.0.0"})
 	err := root.Execute()
 	if err == nil {
 		t.Error("install --target all: expected error")
@@ -63,7 +63,7 @@ func TestInstall_HappyPathNoDeps(t *testing.T) {
 	out := &strings.Builder{}
 	root := NewRootCommand()
 	root.SetOut(out)
-	root.SetArgs([]string{"install", "--target", "cursor", "oci:" + layoutDir + ":install-test:1.0.0"})
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", "oci:" + layoutDir + ":install-test:1.0.0"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("install: %v", err)
 	}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -23,8 +23,6 @@ func NewRootCommand() *cobra.Command {
 	cmd.AddCommand(newPackCmd())
 	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newPullCmd())
-	cmd.AddCommand(newInstallCmd())
-	cmd.AddCommand(newUninstallCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newSkillCmd())
 	return cmd

--- a/internal/cli/skill.go
+++ b/internal/cli/skill.go
@@ -10,5 +10,7 @@ func newSkillCmd() *cobra.Command {
 		Short: "Manage skills",
 	}
 	cmd.AddCommand(newSkillListCmd())
+	cmd.AddCommand(newInstallCmd())
+	cmd.AddCommand(newUninstallCmd())
 	return cmd
 }

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -16,7 +16,7 @@ func newUninstallCmd() *cobra.Command {
 		Use:     "uninstall",
 		Short:   "Remove a previously installed skill and orphaned dependencies",
 		Long:    "Removes the named skill from the given --target (cursor or claude) and removes any dependencies that are no longer required by other installed skills.",
-		Example: "  striatum uninstall --target cursor my-skill",
+		Example: "  striatum skill uninstall --target cursor my-skill",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestUninstall_MissingTargetErrors(t *testing.T) {
 	root := NewRootCommand()
-	root.SetArgs([]string{"uninstall", "foo"})
+	root.SetArgs([]string{"skill", "uninstall", "foo"})
 	err := root.Execute()
 	if err == nil {
 		t.Error("uninstall without --target: expected error")
@@ -29,7 +29,7 @@ func TestUninstall_UnknownNameErrors(t *testing.T) {
 	t.Setenv("HOME", home)
 	// No DB or empty DB
 	root := NewRootCommand()
-	root.SetArgs([]string{"uninstall", "--target", "cursor", "nonexistent"})
+	root.SetArgs([]string{"skill", "uninstall", "--target", "cursor", "nonexistent"})
 	err := root.Execute()
 	if err == nil {
 		t.Error("uninstall unknown name: expected error")
@@ -91,7 +91,7 @@ func TestUninstall_RemovesSkillAndOrphans(t *testing.T) {
 	out := &strings.Builder{}
 	root := NewRootCommand()
 	root.SetOut(out)
-	root.SetArgs([]string{"uninstall", "--target", "cursor", "skill-a"})
+	root.SetArgs([]string{"skill", "uninstall", "--target", "cursor", "skill-a"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestUninstall_SkipsOrphanCleanupWhenRootManifestUnloadable(t *testing.T) {
 	out := &strings.Builder{}
 	root := NewRootCommand()
 	root.SetOut(out)
-	root.SetArgs([]string{"uninstall", "--target", "cursor", "skill-a"})
+	root.SetArgs([]string{"skill", "uninstall", "--target", "cursor", "skill-a"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}

--- a/pkg/artifact/manifest.go
+++ b/pkg/artifact/manifest.go
@@ -6,11 +6,22 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
 const supportedAPIVersion = "striatum.dev/v1alpha1"
-const supportedKindSkill = "Skill"
+
+// supportedKinds lists all artifact kinds accepted by Validate.
+// Add new kinds here as they are introduced.
+var supportedKinds = map[string]bool{
+	"Skill": true,
+}
+
+// IsSupportedKind reports whether kind is a recognized artifact kind.
+func IsSupportedKind(kind string) bool {
+	return supportedKinds[kind]
+}
 
 // Manifest is the root type for artifact.json.
 type Manifest struct {
@@ -65,8 +76,8 @@ func Validate(m *Manifest) error {
 	if m.APIVersion != supportedAPIVersion {
 		return fmt.Errorf("unsupported apiVersion %q, want %s", m.APIVersion, supportedAPIVersion)
 	}
-	if m.Kind != supportedKindSkill {
-		return fmt.Errorf("unsupported kind %q, want %s", m.Kind, supportedKindSkill)
+	if !supportedKinds[m.Kind] {
+		return fmt.Errorf("unsupported kind %q; supported: %s", m.Kind, supportedKindsList())
 	}
 	if strings.TrimSpace(m.Metadata.Name) == "" {
 		return errors.New("metadata.name is required and must be non-empty")
@@ -116,4 +127,13 @@ func ValidateLocal(m *Manifest, baseDir string) error {
 		}
 	}
 	return nil
+}
+
+func supportedKindsList() string {
+	kinds := make([]string, 0, len(supportedKinds))
+	for k := range supportedKinds {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	return strings.Join(kinds, ", ")
 }

--- a/pkg/artifact/manifest.go
+++ b/pkg/artifact/manifest.go
@@ -23,6 +23,12 @@ func IsSupportedKind(kind string) bool {
 	return supportedKinds[kind]
 }
 
+// SupportedKindsList returns a comma-separated list of supported artifact kinds (e.g. "Skill").
+// Useful for error messages when kind validation fails.
+func SupportedKindsList() string {
+	return supportedKindsList()
+}
+
 // Manifest is the root type for artifact.json.
 type Manifest struct {
 	APIVersion   string       `json:"apiVersion"`

--- a/pkg/installer/list.go
+++ b/pkg/installer/list.go
@@ -54,6 +54,9 @@ func ListCachedSkills() ([]CachedSkill, error) {
 		if err != nil {
 			continue
 		}
+		if m.Kind != "Skill" {
+			continue
+		}
 		result = append(result, CachedSkill{Name: skillName, Version: version, Description: m.Metadata.Description})
 	}
 	sort.Slice(result, func(i, j int) bool {

--- a/pkg/installer/list_test.go
+++ b/pkg/installer/list_test.go
@@ -93,6 +93,29 @@ func TestListCachedSkills_MultipleEntriesSorted(t *testing.T) {
 	}
 }
 
+func TestListCachedSkills_SkipsNonSkillKind(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", dir)
+	cacheDir := CacheDir("other-type", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Valid manifest but kind is not Skill — should be omitted from list
+	writeArtifactManifest(t, cacheDir, &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "VectorIndex",
+		Metadata:   artifact.Metadata{Name: "other-type", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "index.json", Files: []string{"index.json"}},
+	})
+	got, err := ListCachedSkills()
+	if err != nil {
+		t.Fatalf("ListCachedSkills(): err = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d, want 0 (non-Skill kind should be skipped)", len(got))
+	}
+}
+
 func TestListCachedSkills_SkipsCorruptManifest(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("STRIATUM_HOME", dir)

--- a/pkg/oci/constants.go
+++ b/pkg/oci/constants.go
@@ -2,7 +2,7 @@ package oci
 
 import "strings"
 
-// Striatum OCI media types (see docs/MVP.md).
+// Striatum OCI media types (see docs/demo.md).
 const (
 	ConfigMediaType = "application/vnd.striatum.artifact.config.v1+json"
 	LayerMediaType  = "application/vnd.striatum.artifact.layer.v1.file"

--- a/pkg/oci/constants.go
+++ b/pkg/oci/constants.go
@@ -1,9 +1,17 @@
 package oci
 
+import "strings"
+
 // Striatum OCI media types (see docs/MVP.md).
 const (
 	ConfigMediaType = "application/vnd.striatum.artifact.config.v1+json"
-	LayerMediaType  = "application/vnd.striatum.skill.layer.v1.file"
-	// ArtifactType is the OCI artifact type for Striatum skills.
-	ArtifactType = "application/vnd.striatum.skill.v1"
+	LayerMediaType  = "application/vnd.striatum.artifact.layer.v1.file"
 )
+
+// ArtifactTypeForKind returns the OCI artifactType for the given artifact kind.
+// The kind must be a non-empty, validated kind (e.g. "Skill"); callers should
+// run artifact.Validate before calling this.
+// Example: "Skill" -> "application/vnd.striatum.skill.v1"
+func ArtifactTypeForKind(kind string) string {
+	return "application/vnd.striatum." + strings.ToLower(kind) + ".v1"
+}

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -74,7 +74,7 @@ func packToTarget(ctx context.Context, m *artifact.Manifest, baseDir string, tar
 		ConfigDescriptor: &configDesc,
 		Layers:           layers,
 	}
-	manifestDesc, err := oras.PackManifest(ctx, target, oras.PackManifestVersion1_1, ArtifactType, opts)
+	manifestDesc, err := oras.PackManifest(ctx, target, oras.PackManifestVersion1_1, ArtifactTypeForKind(m.Kind), opts)
 	if err != nil {
 		return fmt.Errorf("pack manifest: %w", err)
 	}

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -51,12 +51,12 @@ echo "Pulling example-skill and dependencies..."
 "$STRIATUM" pull "$REGISTRY_NAME/example-skill:1.0.0" -o "$OUT_DIR"
 echo "Pulled to $OUT_DIR"
 
-# Install (requires --target)
+# Skill install (requires --target)
 echo "Installing to Cursor target..."
-"$STRIATUM" install --target cursor "$REGISTRY_NAME/example-skill:1.0.0"
+"$STRIATUM" skill install --target cursor "$REGISTRY_NAME/example-skill:1.0.0"
 
-# Uninstall
+# Skill uninstall
 echo "Uninstalling example-skill..."
-"$STRIATUM" uninstall --target cursor example-skill
+"$STRIATUM" skill uninstall --target cursor example-skill
 
-echo "Demo complete: pack → push → pull → install → uninstall."
+echo "Demo complete: pack → push → pull → skill install → skill uninstall."


### PR DESCRIPTION
…` input validation for required fields (`--name`, `--kind`, `--entrypoint`) and add artifact kind support. Update docs, tests, and examples accordingly.