### PR TITLE
Refactor OCI artifact inspection logic to reuse `loadArtifactFromOCI`…

### DIFF
--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -107,3 +107,24 @@ func TestUnknownSubcommand_ReturnsError(t *testing.T) {
 		t.Error("striatum unknown-subcommand: expected error, got nil")
 	}
 }
+
+// operational errors must not be drowned out by a full Cobra usage dump.
+func TestExecute_SilenceUsage_NoUsageDumpOnRunEError(t *testing.T) {
+	root := NewRootCommand()
+	silenceRootPresentation(root)
+	out := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	root.SetOut(out)
+	root.SetErr(errBuf)
+	root.SetArgs([]string{"inspect", "missing-colon-so-invalid"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid reference")
+	}
+	combined := out.String() + errBuf.String()
+	for _, needle := range []string{"Usage:", "Flags:", "Examples:"} {
+		if strings.Contains(combined, needle) {
+			t.Errorf("output must not contain Cobra usage marker %q; stdout+stderr:\n%s", needle, combined)
+		}
+	}
+}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -108,7 +108,8 @@ func TestUnknownSubcommand_ReturnsError(t *testing.T) {
 	}
 }
 
-// operational errors must not be drowned out by a full Cobra usage dump.
+// TestExecute_SilenceUsage_NoUsageDumpOnRunEError asserts that with root
+// silenceRootPresentation, RunE failures do not print a full Cobra usage dump.
 func TestExecute_SilenceUsage_NoUsageDumpOnRunEError(t *testing.T) {
 	root := NewRootCommand()
 	silenceRootPresentation(root)

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -23,7 +23,7 @@ func newInspectCmd() *cobra.Command {
 			}
 			m, err := oci.Inspect(cmd.Context(), target, ref)
 			if err != nil {
-				return fmt.Errorf("failed to inspect: %w", err)
+				return fmt.Errorf("inspect artifact manifest and metadata: %w", err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Name:         %s\n", m.Metadata.Name)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Version:      %s\n", m.Metadata.Version)

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -23,7 +23,7 @@ func newInspectCmd() *cobra.Command {
 			}
 			m, err := oci.Inspect(cmd.Context(), target, ref)
 			if err != nil {
-				return fmt.Errorf("inspect artifact: %w", err)
+				return fmt.Errorf("failed to inspect: %w", err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Name:         %s\n", m.Metadata.Name)
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Version:      %s\n", m.Metadata.Version)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -191,7 +191,7 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath, registryFlag
 		}
 		rootManifest, err = oci.Inspect(ctx, targetObj, ref)
 		if err != nil {
-			return fmt.Errorf("inspect artifact: %w", err)
+			return fmt.Errorf("read artifact manifest: %w", err)
 		}
 	}
 	isOCI := strings.HasPrefix(reference, "oci:")

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -35,7 +35,7 @@ func newPullCmd() *cobra.Command {
 			ctx := cmd.Context()
 			rootManifest, err := oci.Inspect(ctx, target, ref)
 			if err != nil {
-				return fmt.Errorf("inspect artifact: %w", err)
+				return fmt.Errorf("read artifact manifest: %w", err)
 			}
 			if outputDir == "" {
 				outputDir = filepath.Join(wd, rootManifest.Metadata.Name)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -28,10 +28,16 @@ func NewRootCommand() *cobra.Command {
 	return cmd
 }
 
+// silenceRootPresentation matches Execute: no usage dump on RunE errors, errors returned not printed by Cobra.
+func silenceRootPresentation(cmd *cobra.Command) {
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+}
+
 // Execute runs the root command. It is called from main.
 func Execute() {
 	cmd := NewRootCommand()
-	cmd.SilenceErrors = true
+	silenceRootPresentation(cmd)
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -11,34 +11,46 @@ import (
 	"oras.land/oras-go/v2/content"
 )
 
+// loadArtifactFromOCI resolves ref, fetches the OCI image manifest and config blob
+// once, and returns the OCI manifest (for layers), the parsed artifact manifest,
+// and the raw config JSON (for writing artifact.json without re-fetching).
+func loadArtifactFromOCI(ctx context.Context, target oras.ReadOnlyTarget, ref string) (ocispec.Manifest, *artifact.Manifest, []byte, error) {
+	var zero ocispec.Manifest
+	desc, err := target.Resolve(ctx, ref)
+	if err != nil {
+		return zero, nil, nil, fmt.Errorf("resolve %q: %w", ref, err)
+	}
+
+	manifestBytes, err := content.FetchAll(ctx, target, desc)
+	if err != nil {
+		return zero, nil, nil, fmt.Errorf("fetch manifest: %w", err)
+	}
+
+	var ociManifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &ociManifest); err != nil {
+		return zero, nil, nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	configBytes, err := content.FetchAll(ctx, target, ociManifest.Config)
+	if err != nil {
+		return zero, nil, nil, fmt.Errorf("fetch config: %w", err)
+	}
+
+	var m artifact.Manifest
+	if err := json.Unmarshal(configBytes, &m); err != nil {
+		return zero, nil, nil, fmt.Errorf("parse artifact config: %w", err)
+	}
+	return ociManifest, &m, configBytes, nil
+}
+
 // Inspect fetches the artifact manifest from the target for the given reference
 // (e.g. "name:1.0.0" or a full registry reference). It resolves the reference,
 // fetches the OCI manifest, then fetches the config blob and unmarshals it as
 // artifact manifest.
 func Inspect(ctx context.Context, target oras.ReadOnlyTarget, ref string) (*artifact.Manifest, error) {
-	desc, err := target.Resolve(ctx, ref)
+	_, m, _, err := loadArtifactFromOCI(ctx, target, ref)
 	if err != nil {
-		return nil, fmt.Errorf("resolve %q: %w", ref, err)
+		return nil, err
 	}
-
-	manifestBytes, err := content.FetchAll(ctx, target, desc)
-	if err != nil {
-		return nil, fmt.Errorf("fetch manifest: %w", err)
-	}
-
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return nil, fmt.Errorf("parse manifest: %w", err)
-	}
-
-	configBytes, err := content.FetchAll(ctx, target, manifest.Config)
-	if err != nil {
-		return nil, fmt.Errorf("fetch config: %w", err)
-	}
-
-	var m artifact.Manifest
-	if err := json.Unmarshal(configBytes, &m); err != nil {
-		return nil, fmt.Errorf("parse artifact config: %w", err)
-	}
-	return &m, nil
+	return m, nil
 }

--- a/pkg/oci/inspect.go
+++ b/pkg/oci/inspect.go
@@ -23,17 +23,17 @@ func loadArtifactFromOCI(ctx context.Context, target oras.ReadOnlyTarget, ref st
 
 	manifestBytes, err := content.FetchAll(ctx, target, desc)
 	if err != nil {
-		return zero, nil, nil, fmt.Errorf("fetch manifest: %w", err)
+		return zero, nil, nil, fmt.Errorf("fetch OCI manifest: %w", err)
 	}
 
 	var ociManifest ocispec.Manifest
 	if err := json.Unmarshal(manifestBytes, &ociManifest); err != nil {
-		return zero, nil, nil, fmt.Errorf("parse manifest: %w", err)
+		return zero, nil, nil, fmt.Errorf("parse OCI manifest: %w", err)
 	}
 
 	configBytes, err := content.FetchAll(ctx, target, ociManifest.Config)
 	if err != nil {
-		return zero, nil, nil, fmt.Errorf("fetch config: %w", err)
+		return zero, nil, nil, fmt.Errorf("fetch OCI config blob: %w", err)
 	}
 
 	var m artifact.Manifest

--- a/pkg/oci/pull.go
+++ b/pkg/oci/pull.go
@@ -2,13 +2,11 @@ package oci
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 )
@@ -29,24 +27,9 @@ func safeLayerPath(name string) (string, error) {
 // Pull fetches the artifact from the target for the given reference and
 // extracts it to outputDir/<artifact-name>/ (artifact.json plus all layer files).
 func Pull(ctx context.Context, target oras.ReadOnlyTarget, ref string, outputDir string) error {
-	m, err := Inspect(ctx, target, ref)
+	manifest, m, configBytes, err := loadArtifactFromOCI(ctx, target, ref)
 	if err != nil {
-		return fmt.Errorf("inspect artifact: %w", err)
-	}
-
-	desc, err := target.Resolve(ctx, ref)
-	if err != nil {
-		return fmt.Errorf("resolve %q: %w", ref, err)
-	}
-
-	manifestBytes, err := content.FetchAll(ctx, target, desc)
-	if err != nil {
-		return fmt.Errorf("fetch manifest: %w", err)
-	}
-
-	var manifest ocispec.Manifest
-	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
-		return fmt.Errorf("parse manifest: %w", err)
+		return fmt.Errorf("read artifact manifest: %w", err)
 	}
 
 	artifactPath := filepath.Join(outputDir, m.Metadata.Name)
@@ -54,10 +37,6 @@ func Pull(ctx context.Context, target oras.ReadOnlyTarget, ref string, outputDir
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	configBytes, err := content.FetchAll(ctx, target, manifest.Config)
-	if err != nil {
-		return fmt.Errorf("fetch config: %w", err)
-	}
 	if err := os.WriteFile(filepath.Join(artifactPath, "artifact.json"), configBytes, 0o600); err != nil {
 		return fmt.Errorf("write artifact.json: %w", err)
 	}


### PR DESCRIPTION
…; improve error handling and streamline manifest operations

Resolves #6 