### PR TITLE
Add support for `-f`/`--manifest` flag in `validate`, `pack`, and `pu…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,9 @@ go test -tags=integration ./...
 | Command | Purpose |
 | ------- | ------- |
 | `striatum init` | Scaffold `artifact.json` (requires `--name`, `--kind`, `--entrypoint`) |
-| `striatum validate` | Validate artifact (optional `--check-deps`) |
-| `striatum pack` | Bundle into local OCI Image Layout |
-| `striatum push <ref>` | Push to OCI registry |
+| `striatum validate` | Validate artifact (optional `--check-deps`; `-f` / `--manifest` for non-CWD `artifact.json`) |
+| `striatum pack` | Bundle into local OCI Image Layout (`-f` / `--manifest` supported) |
+| `striatum push <ref>` | Push to OCI registry (`-f` / `--manifest` supported) |
 | `striatum pull <ref>` | Pull artifact and deps |
 | `striatum inspect <ref>` | Show remote artifact metadata |
 | `striatum skill install <ref>` | Install skill into Cursor/Claude skills dirs |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ go test -tags=integration ./...
 ## Conventions
 
 - **Go**: Prefer standard library and existing deps (`oras.land/oras-go/v2`, `github.com/spf13/cobra`, `github.com/opencontainers/image-spec`).
-- **CLI**: Subcommands and flags live in `internal/cli/`; registry and artifact logic in `pkg/`.
+- **CLI**: Subcommands and flags live in `internal/cli/`; registry and artifact logic in `pkg/`. For validate, pack, and push, `-f` / `--manifest` selects a manifest **file** only when the basename is `artifact.json` (case-insensitive); any other basename is treated as a project directory and `artifact.json` is appended.
 - **Docs**: [README.md](README.md) is the source of truth for behavior; [docs/demo.md](docs/demo.md) for end-to-end flows.
 
 ## Commands (reference)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ go test -tags=integration ./...
 
 ## Commands
 
+For `validate`, `pack`, and `push`, use `-f` / `--manifest` with a path to `artifact.json` or to the project directory that contains it (defaults to `./artifact.json` in the current working directory). Paths in `spec.files` are always resolved relative to the directory that contains the manifest, not the shell’s current directory.
+
 - `striatum init` — scaffold an `artifact.json` (requires `--name`, `--kind`, `--entrypoint`)
 - `striatum validate` — validate local artifact and optionally check dependencies
 - `striatum pack` — bundle artifact into a local OCI Image Layout
@@ -37,9 +39,12 @@ go test -tags=integration ./...
 ```bash
 striatum init --name my-skill --kind Skill --entrypoint SKILL.md
 striatum validate
+striatum validate -f packages/my-skill
 striatum validate --check-deps --registry localhost:5000/skills
 striatum pack
+striatum pack --manifest path/to/artifact.json
 striatum push localhost:5000/skills/my-skill:1.0.0
+striatum push -f ./my-skill localhost:5000/skills/my-skill:1.0.0
 striatum pull localhost:5000/skills/my-skill:1.0.0
 striatum skill install --target cursor localhost:5000/skills/my-skill:1.0.0
 striatum skill uninstall --target cursor my-skill

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ go test -tags=integration ./...
 
 For `validate`, `pack`, and `push`, use `-f` / `--manifest` with a path to `artifact.json` or to the project directory that contains it (defaults to `./artifact.json` in the current working directory). Paths in `spec.files` are always resolved relative to the directory that contains the manifest, not the shell’s current directory.
 
+The flag treats a path as a manifest **file** only when its final component is named `artifact.json` (case-insensitive, e.g. `Artifact.json` on disk). Any other final component is treated as a **project directory** and `artifact.json` is appended—even if that name is missing—so typos get errors pointing at the expected manifest path.
+
 - `striatum init` — scaffold an `artifact.json` (requires `--name`, `--kind`, `--entrypoint`)
 - `striatum validate` — validate local artifact and optionally check dependencies
 - `striatum pack` — bundle artifact into a local OCI Image Layout

--- a/internal/cli/manifest_path.go
+++ b/internal/cli/manifest_path.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// manifestFlagUsage is the description for -f / --manifest on validate, pack, and push.
+const manifestFlagUsage = "path to artifact.json or project directory containing it; spec.files paths are relative to the manifest's directory (default: ./artifact.json in the current directory)"
+
+// resolveManifestAndProjectRoot returns the absolute path to artifact.json and the
+// project root directory (its parent). Paths in spec.files are interpreted
+// relative to projectRoot.
+//
+// If manifestFlag is empty, uses filepath.Join(cwd, defaultManifestName).
+// If manifestFlag names an existing directory, defaultManifestName is appended.
+func resolveManifestAndProjectRoot(manifestFlag string) (manifestPath, projectRoot string, err error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", "", fmt.Errorf("get working directory: %w", err)
+	}
+	rel := strings.TrimSpace(manifestFlag)
+	var candidate string
+	if rel == "" {
+		candidate = filepath.Join(wd, defaultManifestName)
+	} else if filepath.IsAbs(rel) {
+		candidate = filepath.Clean(rel)
+	} else {
+		candidate = filepath.Clean(filepath.Join(wd, rel))
+	}
+	if fi, statErr := os.Stat(candidate); statErr == nil && fi.IsDir() {
+		candidate = filepath.Join(candidate, defaultManifestName)
+	}
+	manifestPath, err = filepath.Abs(candidate)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve manifest path: %w", err)
+	}
+	projectRoot = filepath.Dir(manifestPath)
+	return manifestPath, projectRoot, nil
+}

--- a/internal/cli/manifest_path.go
+++ b/internal/cli/manifest_path.go
@@ -8,14 +8,20 @@ import (
 )
 
 // manifestFlagUsage is the description for -f / --manifest on validate, pack, and push.
-const manifestFlagUsage = "path to artifact.json or project directory containing it; spec.files paths are relative to the manifest's directory (default: ./artifact.json in the current directory)"
+const manifestFlagUsage = "path to a project directory (uses artifact.json inside) or to a manifest file whose basename is artifact.json (case-insensitive); any other basename is treated as a directory and artifact.json is appended; spec.files are relative to the manifest directory (default: ./artifact.json in cwd)"
+
+const defaultManifestName = "artifact.json"
 
 // resolveManifestAndProjectRoot returns the absolute path to artifact.json and the
 // project root directory (its parent). Paths in spec.files are interpreted
 // relative to projectRoot.
 //
 // If manifestFlag is empty, uses filepath.Join(cwd, defaultManifestName).
-// If manifestFlag names an existing directory, defaultManifestName is appended.
+// When the final path component is not defaultManifestName (compared with
+// strings.EqualFold), the path is treated as a project directory and
+// defaultManifestName is appended (even when that directory does not exist yet),
+// so load errors refer to the intended manifest file. A manifest file with any
+// other basename is not supported via this flag.
 func resolveManifestAndProjectRoot(manifestFlag string) (manifestPath, projectRoot string, err error) {
 	wd, err := os.Getwd()
 	if err != nil {
@@ -30,7 +36,7 @@ func resolveManifestAndProjectRoot(manifestFlag string) (manifestPath, projectRo
 	} else {
 		candidate = filepath.Clean(filepath.Join(wd, rel))
 	}
-	if fi, statErr := os.Stat(candidate); statErr == nil && fi.IsDir() {
+	if !strings.EqualFold(filepath.Base(candidate), defaultManifestName) {
 		candidate = filepath.Join(candidate, defaultManifestName)
 	}
 	manifestPath, err = filepath.Abs(candidate)

--- a/internal/cli/manifest_path_test.go
+++ b/internal/cli/manifest_path_test.go
@@ -1,0 +1,132 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveManifestAndProjectRoot_Default(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot("")
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	wantManifest, err := filepath.Abs(filepath.Join(tmp, defaultManifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotManifest != wantManifest {
+		t.Errorf("manifest path = %q, want %q", gotManifest, wantManifest)
+	}
+	if gotRoot != filepath.Dir(wantManifest) {
+		t.Errorf("project root = %q, want %q", gotRoot, filepath.Dir(wantManifest))
+	}
+}
+
+func TestResolveManifestAndProjectRoot_RelativeFile(t *testing.T) {
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "packages", "myskill")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	manifest := filepath.Join(sub, "artifact.json")
+	if err := os.WriteFile(manifest, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmp)
+
+	rel := filepath.Join("packages", "myskill", "artifact.json")
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot(rel)
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	wantManifest, err := filepath.Abs(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotManifest != wantManifest {
+		t.Errorf("manifest path = %q, want %q", gotManifest, wantManifest)
+	}
+	wantRoot, err := filepath.Abs(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Errorf("project root = %q, want %q", gotRoot, wantRoot)
+	}
+}
+
+func TestResolveManifestAndProjectRoot_AbsoluteFile(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := filepath.Join(tmp, "artifact.json")
+	if err := os.WriteFile(manifest, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(tmp, "other")
+	if err := os.MkdirAll(other, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(other)
+
+	absManifest, err := filepath.Abs(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot(absManifest)
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	if gotManifest != absManifest {
+		t.Errorf("manifest path = %q, want %q", gotManifest, absManifest)
+	}
+	if gotRoot != tmp {
+		t.Errorf("project root = %q, want %q", gotRoot, tmp)
+	}
+}
+
+func TestResolveManifestAndProjectRoot_TrimsWhitespace(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "artifact.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmp)
+
+	_, _, err := resolveManifestAndProjectRoot("  artifact.json  ")
+	if err != nil {
+		t.Fatalf("expected whitespace-trimmed path to resolve: %v", err)
+	}
+}
+
+func TestResolveManifestAndProjectRoot_DirectoryContainsDefaultManifest(t *testing.T) {
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "pkg")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "artifact.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmp)
+
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot("pkg")
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	wantManifest, err := filepath.Abs(filepath.Join(sub, "artifact.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotManifest != wantManifest {
+		t.Errorf("manifest path = %q, want %q", gotManifest, wantManifest)
+	}
+	wantRoot, err := filepath.Abs(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Errorf("project root = %q, want %q", gotRoot, wantRoot)
+	}
+}

--- a/internal/cli/manifest_path_test.go
+++ b/internal/cli/manifest_path_test.go
@@ -87,6 +87,31 @@ func TestResolveManifestAndProjectRoot_AbsoluteFile(t *testing.T) {
 	}
 }
 
+func TestResolveManifestAndProjectRoot_ManifestBasenameCaseInsensitive(t *testing.T) {
+	tmp := t.TempDir()
+	// Use non-canonical casing; resolution must still treat this as the manifest file path.
+	manifest := filepath.Join(tmp, "Artifact.json")
+	if err := os.WriteFile(manifest, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(tmp)
+
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot("Artifact.json")
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	wantManifest, err := filepath.Abs(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotManifest != wantManifest {
+		t.Errorf("manifest path = %q, want %q (must not append second artifact.json)", gotManifest, wantManifest)
+	}
+	if gotRoot != tmp {
+		t.Errorf("project root = %q, want %q", gotRoot, tmp)
+	}
+}
+
 func TestResolveManifestAndProjectRoot_TrimsWhitespace(t *testing.T) {
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "artifact.json"), []byte("{}"), 0o600); err != nil {
@@ -123,6 +148,31 @@ func TestResolveManifestAndProjectRoot_DirectoryContainsDefaultManifest(t *testi
 		t.Errorf("manifest path = %q, want %q", gotManifest, wantManifest)
 	}
 	wantRoot, err := filepath.Abs(sub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRoot != wantRoot {
+		t.Errorf("project root = %q, want %q", gotRoot, wantRoot)
+	}
+}
+
+func TestResolveManifestAndProjectRoot_NonexistentProjectDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	missingDir := filepath.Join(tmp, "typo-proj")
+	wantManifest, err := filepath.Abs(filepath.Join(missingDir, defaultManifestName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotManifest, gotRoot, err := resolveManifestAndProjectRoot("typo-proj")
+	if err != nil {
+		t.Fatalf("resolveManifestAndProjectRoot: %v", err)
+	}
+	if gotManifest != wantManifest {
+		t.Errorf("manifest path = %q, want %q (missing dir should still append %s)", gotManifest, wantManifest, defaultManifestName)
+	}
+	wantRoot, err := filepath.Abs(missingDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -12,14 +12,18 @@ import (
 
 const defaultLayoutDir = ".striatum/oci-layout"
 
-func newPackCmd(manifest *string) *cobra.Command {
+func newPackCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pack",
 		Short:   "Bundle the artifact into a local OCI Image Layout directory",
 		Long:    "Reads artifact.json and spec.files from the manifest's project directory and writes an OCI Image Layout to <project>/.striatum/oci-layout/ for push or local use.",
 		Example: "  striatum pack\n  striatum pack -f packages/my-skill",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
+			manifestFlag, err := cmd.Flags().GetString("manifest")
+			if err != nil {
+				return err
+			}
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
 			}
@@ -34,10 +38,10 @@ func newPackCmd(manifest *string) *cobra.Command {
 			if err := oci.Pack(cmd.Context(), m, projectRoot, layoutPath); err != nil {
 				return fmt.Errorf("pack artifact: %w", err)
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed artifact to %s/\n", defaultLayoutDir)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed artifact to %s/\n", layoutPath)
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -12,32 +12,32 @@ import (
 
 const defaultLayoutDir = ".striatum/oci-layout"
 
-func newPackCmd() *cobra.Command {
+func newPackCmd(manifest *string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "pack",
 		Short:   "Bundle the artifact into a local OCI Image Layout directory",
-		Long:    "Reads artifact.json and spec.files from the current directory and writes an OCI Image Layout to .striatum/oci-layout/ for push or local use.",
-		Example: "  striatum pack",
+		Long:    "Reads artifact.json and spec.files from the manifest's project directory and writes an OCI Image Layout to <project>/.striatum/oci-layout/ for push or local use.",
+		Example: "  striatum pack\n  striatum pack -f packages/my-skill",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			wd, err := os.Getwd()
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return err
 			}
-			manifestPath := filepath.Join(wd, defaultManifestName)
 			m, err := artifact.Load(manifestPath)
 			if err != nil {
 				return fmt.Errorf("load manifest: %w", err)
 			}
-			layoutPath := filepath.Join(wd, defaultLayoutDir)
+			layoutPath := filepath.Join(projectRoot, defaultLayoutDir)
 			if err := os.MkdirAll(layoutPath, 0o755); err != nil {
 				return fmt.Errorf("create layout dir: %w", err)
 			}
-			if err := oci.Pack(cmd.Context(), m, wd, layoutPath); err != nil {
+			if err := oci.Pack(cmd.Context(), m, projectRoot, layoutPath); err != nil {
 				return fmt.Errorf("pack artifact: %w", err)
 			}
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed artifact to %s/\n", defaultLayoutDir)
 			return nil
 		},
 	}
+	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -38,7 +38,7 @@ func newPackCmd() *cobra.Command {
 			if err := oci.Pack(cmd.Context(), m, projectRoot, layoutPath); err != nil {
 				return fmt.Errorf("pack artifact: %w", err)
 			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed artifact to %s/\n", layoutPath)
+			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Packed artifact to %s\n", layoutPath)
 			return nil
 		},
 	}

--- a/internal/cli/pack_test.go
+++ b/internal/cli/pack_test.go
@@ -45,3 +45,44 @@ func TestPack_CreatesLayoutAndPrintsMessage(t *testing.T) {
 		t.Errorf("layout index.json missing: %v", err)
 	}
 }
+
+func TestPack_WithManifestFlagFromOtherDir(t *testing.T) {
+	projectDir := t.TempDir()
+	cwd := t.TempDir()
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "remote-pack", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "SKILL.md"), []byte("# x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"pack", "-f", projectDir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("pack -f from other dir: %v", err)
+	}
+	if !strings.Contains(out.String(), "Packed") {
+		t.Errorf("output %q does not contain Packed", out.String())
+	}
+	idx := filepath.Join(projectDir, ".striatum", "oci-layout", "index.json")
+	if _, err := os.Stat(idx); err != nil {
+		t.Errorf("expected layout under project dir %s: %v", idx, err)
+	}
+	if _, err := os.Stat(filepath.Join(cwd, ".striatum", "oci-layout", "index.json")); err == nil {
+		t.Error("did not expect OCI layout under unrelated cwd")
+	}
+}

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPushCmd(manifest *string) *cobra.Command {
+func newPushCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "push",
 		Short:   "Push the artifact to an OCI registry",
@@ -17,7 +17,11 @@ func newPushCmd(manifest *string) *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reference := args[0]
-			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
+			manifestFlag, err := cmd.Flags().GetString("manifest")
+			if err != nil {
+				return err
+			}
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
 			}
@@ -38,6 +42,6 @@ func newPushCmd(manifest *string) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -2,28 +2,25 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/hbelmiro/striatum/pkg/artifact"
 	"github.com/hbelmiro/striatum/pkg/oci"
 	"github.com/spf13/cobra"
 )
 
-func newPushCmd() *cobra.Command {
-	return &cobra.Command{
+func newPushCmd(manifest *string) *cobra.Command {
+	cmd := &cobra.Command{
 		Use:     "push",
 		Short:   "Push the artifact to an OCI registry",
-		Long:    "Packs the current artifact (artifact.json and spec.files) and pushes it to the given reference (e.g. localhost:5000/repo/my-skill:1.0.0).",
-		Example: "  striatum push localhost:5000/skills/my-skill:1.0.0",
+		Long:    "Packs the artifact (artifact.json and spec.files from the manifest's project directory) and pushes it to the given reference (e.g. localhost:5000/repo/my-skill:1.0.0).",
+		Example: "  striatum push localhost:5000/skills/my-skill:1.0.0\n  striatum push -f path/to/artifact.json localhost:5000/skills/my-skill:1.0.0",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reference := args[0]
-			wd, err := os.Getwd()
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return err
 			}
-			manifestPath := filepath.Join(wd, defaultManifestName)
 			m, err := artifact.Load(manifestPath)
 			if err != nil {
 				return fmt.Errorf("load manifest: %w", err)
@@ -31,14 +28,16 @@ func newPushCmd() *cobra.Command {
 			if err := artifact.Validate(m); err != nil {
 				return fmt.Errorf("invalid manifest: %w", err)
 			}
-			if err := artifact.ValidateLocal(m, wd); err != nil {
+			if err := artifact.ValidateLocal(m, projectRoot); err != nil {
 				return fmt.Errorf("validate local files: %w", err)
 			}
-			if err := oci.Push(cmd.Context(), m, wd, reference); err != nil {
+			if err := oci.Push(cmd.Context(), m, projectRoot, reference); err != nil {
 				return fmt.Errorf("push artifact: %w", err)
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Pushed to", reference)
 			return nil
 		},
 	}
+	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
+	return cmd
 }

--- a/internal/cli/push_test.go
+++ b/internal/cli/push_test.go
@@ -44,3 +44,39 @@ func TestPush_ToOCILayoutSucceeds(t *testing.T) {
 		t.Errorf("output %q does not contain Pushed", out.String())
 	}
 }
+
+func TestPush_WithManifestFlagFromOtherDir(t *testing.T) {
+	projectDir := t.TempDir()
+	layoutDir := t.TempDir()
+	cwd := t.TempDir()
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha1",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "cli-push-remote", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "SKILL.md"), []byte("# x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	ref := "oci:" + layoutDir + ":1.0.0"
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"push", "-f", projectDir, ref})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("push -f from other dir: %v", err)
+	}
+	if !strings.Contains(out.String(), "Pushed") {
+		t.Errorf("output %q does not contain Pushed", out.String())
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,10 +18,12 @@ func NewRootCommand() *cobra.Command {
 	}
 	cmd.Version = version
 	cmd.SetVersionTemplate("striatum version {{.Version}}\n")
+
+	var manifest string
 	cmd.AddCommand(newInitCmd())
-	cmd.AddCommand(newValidateCmd())
-	cmd.AddCommand(newPackCmd())
-	cmd.AddCommand(newPushCmd())
+	cmd.AddCommand(newValidateCmd(&manifest))
+	cmd.AddCommand(newPackCmd(&manifest))
+	cmd.AddCommand(newPushCmd(&manifest))
 	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newSkillCmd())

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -19,11 +19,10 @@ func NewRootCommand() *cobra.Command {
 	cmd.Version = version
 	cmd.SetVersionTemplate("striatum version {{.Version}}\n")
 
-	var manifest string
 	cmd.AddCommand(newInitCmd())
-	cmd.AddCommand(newValidateCmd(&manifest))
-	cmd.AddCommand(newPackCmd(&manifest))
-	cmd.AddCommand(newPushCmd(&manifest))
+	cmd.AddCommand(newValidateCmd())
+	cmd.AddCommand(newPackCmd())
+	cmd.AddCommand(newPushCmd())
 	cmd.AddCommand(newPullCmd())
 	cmd.AddCommand(newInspectCmd())
 	cmd.AddCommand(newSkillCmd())

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -11,7 +11,7 @@ import (
 
 const defaultManifestName = "artifact.json"
 
-func newValidateCmd(manifest *string) *cobra.Command {
+func newValidateCmd() *cobra.Command {
 	var checkDeps bool
 	var registry string
 	cmd := &cobra.Command{
@@ -20,7 +20,11 @@ func newValidateCmd(manifest *string) *cobra.Command {
 		Long:    "Validates schema and that all spec.files exist (paths are relative to the manifest file's directory). Use --check-deps with --registry to verify dependencies resolve in the registry.",
 		Example: "  striatum validate\n  striatum validate -f path/to/artifact.json\n  striatum validate --check-deps --registry localhost:5000/skills",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
+			manifestFlag, err := cmd.Flags().GetString("manifest")
+			if err != nil {
+				return err
+			}
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
 			}
@@ -34,7 +38,7 @@ func newValidateCmd(manifest *string) *cobra.Command {
 			if err := artifact.ValidateLocal(m, projectRoot); err != nil {
 				return fmt.Errorf("validate local files: %w", err)
 			}
-			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "artifact.json is valid.")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Manifest is valid.")
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "All files referenced in spec.files exist.")
 
 			if checkDeps {
@@ -66,6 +70,6 @@ func newValidateCmd(manifest *string) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&checkDeps, "check-deps", false, "Verify all dependencies exist in the registry")
 	cmd.Flags().StringVar(&registry, "registry", "", "Registry base URL (required with --check-deps, e.g. localhost:5000/skills)")
-	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -9,8 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultManifestName = "artifact.json"
-
 func newValidateCmd() *cobra.Command {
 	var checkDeps bool
 	var registry string

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -2,8 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/hbelmiro/striatum/pkg/artifact"
@@ -13,28 +11,27 @@ import (
 
 const defaultManifestName = "artifact.json"
 
-func newValidateCmd() *cobra.Command {
+func newValidateCmd(manifest *string) *cobra.Command {
 	var checkDeps bool
 	var registry string
 	cmd := &cobra.Command{
 		Use:     "validate",
 		Short:   "Validate the local artifact.json",
-		Long:    "Validates schema and that all spec.files exist. Use --check-deps with --registry to verify dependencies resolve in the registry.",
-		Example: "  striatum validate\n  striatum validate --check-deps --registry localhost:5000/skills",
+		Long:    "Validates schema and that all spec.files exist (paths are relative to the manifest file's directory). Use --check-deps with --registry to verify dependencies resolve in the registry.",
+		Example: "  striatum validate\n  striatum validate -f path/to/artifact.json\n  striatum validate --check-deps --registry localhost:5000/skills",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			wd, err := os.Getwd()
+			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(*manifest)
 			if err != nil {
-				return fmt.Errorf("get working directory: %w", err)
+				return err
 			}
-			path := filepath.Join(wd, defaultManifestName)
-			m, err := artifact.Load(path)
+			m, err := artifact.Load(manifestPath)
 			if err != nil {
 				return fmt.Errorf("load manifest: %w", err)
 			}
 			if err := artifact.Validate(m); err != nil {
 				return fmt.Errorf("invalid manifest: %w", err)
 			}
-			if err := artifact.ValidateLocal(m, wd); err != nil {
+			if err := artifact.ValidateLocal(m, projectRoot); err != nil {
 				return fmt.Errorf("validate local files: %w", err)
 			}
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "artifact.json is valid.")
@@ -69,5 +66,6 @@ func newValidateCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&checkDeps, "check-deps", false, "Verify all dependencies exist in the registry")
 	cmd.Flags().StringVar(&registry, "registry", "", "Registry base URL (required with --check-deps, e.g. localhost:5000/skills)")
+	cmd.Flags().StringVarP(manifest, "manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/validate_test.go
+++ b/internal/cli/validate_test.go
@@ -133,3 +133,47 @@ func TestValidate_CheckDepsWithRegistryNoDeps(t *testing.T) {
 		t.Errorf("output %q does not contain All dependencies resolved", got)
 	}
 }
+
+func TestValidate_SuccessWithManifestFlagFromOtherDir(t *testing.T) {
+	projectDir := t.TempDir()
+	cwd := t.TempDir()
+	valid := `{"apiVersion":"striatum.dev/v1alpha1","kind":"Skill","metadata":{"name":"x","version":"1.0.0"},"spec":{"entrypoint":"SKILL.md","files":["SKILL.md"]}}`
+	if err := os.WriteFile(filepath.Join(projectDir, "artifact.json"), []byte(valid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "SKILL.md"), []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"validate", "--manifest", filepath.Join(projectDir, "artifact.json")})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("validate --manifest from other dir: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "valid") {
+		t.Errorf("output %q does not contain valid", got)
+	}
+}
+
+func TestValidate_FileMissingWithManifestFromOtherDir(t *testing.T) {
+	projectDir := t.TempDir()
+	cwd := t.TempDir()
+	valid := `{"apiVersion":"striatum.dev/v1alpha1","kind":"Skill","metadata":{"name":"x","version":"1.0.0"},"spec":{"entrypoint":"SKILL.md","files":["SKILL.md","other.md"]}}`
+	if err := os.WriteFile(filepath.Join(projectDir, "artifact.json"), []byte(valid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "SKILL.md"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"validate", "-f", filepath.Join(projectDir, "artifact.json")})
+	if err := root.Execute(); err == nil {
+		t.Fatal("validate -f with missing spec file: expected error, got nil")
+	}
+}

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -21,7 +21,7 @@ const annotationTitle = "org.opencontainers.image.title"
 
 // Pack builds an OCI image from the artifact manifest and writes it to the
 // OCI Image Layout at layoutPath. The manifest must be valid; all spec.files
-// must exist under baseDir.
+// paths are read relative to baseDir (the directory containing artifact.json).
 func Pack(ctx context.Context, m *artifact.Manifest, baseDir string, layoutPath string) error {
 	if m == nil {
 		return errors.New("manifest is nil")

--- a/pkg/oci/pack.go
+++ b/pkg/oci/pack.go
@@ -21,7 +21,8 @@ const annotationTitle = "org.opencontainers.image.title"
 
 // Pack builds an OCI image from the artifact manifest and writes it to the
 // OCI Image Layout at layoutPath. The manifest must be valid; all spec.files
-// paths are read relative to baseDir (the directory containing artifact.json).
+// paths are read relative to baseDir, the root directory used to resolve those
+// paths (for example, the directory containing artifact.json).
 func Pack(ctx context.Context, m *artifact.Manifest, baseDir string, layoutPath string) error {
 	if m == nil {
 		return errors.New("manifest is nil")


### PR DESCRIPTION
…sh` commands; update CLI to resolve artifact paths relative to manifest

Resolves #14 