### PR TITLE
Use unique staging directory per pull to prevent stale cache files

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -306,10 +306,14 @@ func runLocalInstall(cmd *cobra.Command, reference, target, projectPath string, 
 			res := r
 			depCacheDir := installer.CacheDir(res.Name, res.Version)
 			pullFn := func(ctx context.Context, _ string) error {
-				if err := pullDependency(ctx, res.Dependency, cacheRoot); err != nil {
+				created, cleanup, err := pullToStagingDir(cacheRoot, res.Name, func(stagingDir string) error {
+					return pullDependency(ctx, res.Dependency, stagingDir)
+				})
+				if err != nil {
+					cleanup()
 					return err
 				}
-				created := filepath.Join(cacheRoot, res.Name)
+				defer cleanup()
 				return atomicReplaceCacheDir(created, depCacheDir)
 			}
 			var digestFn installer.DigestFunc
@@ -510,13 +514,14 @@ func repullToCache(ctx context.Context, sourceRef, cacheDir, name string) error 
 		return fmt.Errorf("parse reference %q: %w", sourceRef, err)
 	}
 	cacheRoot := filepath.Join(installer.CacheRoot(), "cache")
-	if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
-		return fmt.Errorf("create cache root: %w", err)
-	}
-	if err := defaultRouter().Pull(ctx, loc, cacheRoot); err != nil {
+	created, cleanup, err := pullToStagingDir(cacheRoot, name, func(stagingDir string) error {
+		return defaultRouter().Pull(ctx, loc, stagingDir)
+	})
+	if err != nil {
+		cleanup()
 		return fmt.Errorf("pull artifact %q: %w", sourceRef, err)
 	}
-	created := filepath.Join(cacheRoot, name)
+	defer cleanup()
 	if _, err := os.Stat(created); err != nil {
 		return fmt.Errorf("expected artifact directory %q after pull (artifact metadata.name may differ from installed name %q): %w", created, name, err)
 	}
@@ -583,25 +588,32 @@ func ensureArtifactsInCache(ctx context.Context, reference string, rootTarget or
 		}
 
 		pullFn := func(ctx context.Context, _ string) error {
-			if idx == 0 {
-				pullTarget := rootTarget
-				pullRef := rootRef
-				if pullTarget == nil {
-					resolvedTarget, resolvedRef, err := resolveTargetAndRef(reference)
-					if err != nil {
-						return fmt.Errorf("root was loaded from cache but cache is no longer present; cannot re-pull: %w", err)
+			created, cleanup, err := pullToStagingDir(cacheRoot, res.Name, func(stagingDir string) error {
+				if idx == 0 {
+					pullTarget := rootTarget
+					pullRef := rootRef
+					if pullTarget == nil {
+						resolvedTarget, resolvedRef, err := resolveTargetAndRef(reference)
+						if err != nil {
+							return fmt.Errorf("root was loaded from cache but cache is no longer present; cannot re-pull: %w", err)
+						}
+						pullTarget, pullRef = resolvedTarget, resolvedRef
 					}
-					pullTarget, pullRef = resolvedTarget, resolvedRef
+					if err := oci.Pull(ctx, pullTarget, pullRef, stagingDir); err != nil {
+						return fmt.Errorf("download OCI artifact: %w", err)
+					}
+				} else {
+					if err := pullDependency(ctx, res.Dependency, stagingDir); err != nil {
+						return err
+					}
 				}
-				if err := oci.Pull(ctx, pullTarget, pullRef, cacheRoot); err != nil {
-					return fmt.Errorf("download OCI artifact: %w", err)
-				}
-			} else {
-				if err := pullDependency(ctx, res.Dependency, cacheRoot); err != nil {
-					return err
-				}
+				return nil
+			})
+			if err != nil {
+				cleanup()
+				return err
 			}
-			created := filepath.Join(cacheRoot, res.Name)
+			defer cleanup()
 			if err := atomicReplaceCacheDir(created, cacheDir); err != nil {
 				return fmt.Errorf("finalize cache directory: %w", err)
 			}
@@ -620,6 +632,24 @@ func pullDependency(ctx context.Context, dep artifact.Dependency, outputDir stri
 		return fmt.Errorf("nil dependency")
 	}
 	return defaultRouter().Pull(ctx, dep, outputDir)
+}
+
+// pullToStagingDir creates a unique temporary directory under parentDir,
+// calls pullFn with it, and returns the path to the artifact subdirectory
+// (tmpDir/<artifactName>). The caller MUST call cleanup when done.
+func pullToStagingDir(parentDir, artifactName string, pullFn func(stagingDir string) error) (artifactDir string, cleanup func(), err error) {
+	if err := os.MkdirAll(parentDir, 0o755); err != nil {
+		return "", func() {}, fmt.Errorf("create parent dir: %w", err)
+	}
+	tmpDir, err := os.MkdirTemp(parentDir, ".staging-"+artifactName+"-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create staging dir: %w", err)
+	}
+	cleanupFn := func() { _ = os.RemoveAll(tmpDir) }
+	if err := pullFn(tmpDir); err != nil {
+		return "", cleanupFn, err
+	}
+	return filepath.Join(tmpDir, artifactName), cleanupFn, nil
 }
 
 // atomicReplaceCacheDir moves created (fresh pull) to cacheDir, removing cacheDir first if it exists

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -638,6 +638,9 @@ func pullDependency(ctx context.Context, dep artifact.Dependency, outputDir stri
 // calls pullFn with it, and returns the path to the artifact subdirectory
 // (tmpDir/<artifactName>). The caller MUST call cleanup when done.
 func pullToStagingDir(parentDir, artifactName string, pullFn func(stagingDir string) error) (artifactDir string, cleanup func(), err error) {
+	if strings.ContainsAny(artifactName, "/\\") || strings.Contains(artifactName, "..") {
+		return "", func() {}, fmt.Errorf("unsafe artifact name %q", artifactName)
+	}
 	if err := os.MkdirAll(parentDir, 0o755); err != nil {
 		return "", func() {}, fmt.Errorf("create parent dir: %w", err)
 	}

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1371,5 +1372,197 @@ func TestInstall_LocalDir_WithDeps(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 DB entries, got %d", len(entries))
+	}
+}
+
+func TestPullToStagingDir_CreatesIsolatedDir(t *testing.T) {
+	parentDir := t.TempDir()
+
+	var capturedStagingDir string
+	artifactDir, cleanup, err := pullToStagingDir(parentDir, "my-artifact", func(stagingDir string) error {
+		capturedStagingDir = stagingDir
+
+		if !strings.HasPrefix(filepath.Base(stagingDir), ".staging-my-artifact-") {
+			t.Errorf("staging dir name should start with .staging-my-artifact-, got %q", filepath.Base(stagingDir))
+		}
+
+		rel, relErr := filepath.Rel(parentDir, stagingDir)
+		if relErr != nil || strings.HasPrefix(rel, "..") {
+			t.Errorf("staging dir should be under parentDir, got %q", stagingDir)
+		}
+
+		entries, readErr := os.ReadDir(stagingDir)
+		if readErr != nil {
+			t.Fatalf("read staging dir: %v", readErr)
+		}
+		if len(entries) != 0 {
+			t.Errorf("staging dir should start empty, got %d entries", len(entries))
+		}
+
+		if err := os.MkdirAll(filepath.Join(stagingDir, "my-artifact"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return os.WriteFile(filepath.Join(stagingDir, "my-artifact", "test.txt"), []byte("data"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("pullToStagingDir: %v", err)
+	}
+	defer cleanup()
+
+	expectedArtifactDir := filepath.Join(capturedStagingDir, "my-artifact")
+	if artifactDir != expectedArtifactDir {
+		t.Errorf("artifactDir = %q, want %q", artifactDir, expectedArtifactDir)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "test.txt")); err != nil {
+		t.Errorf("test.txt should exist in artifactDir: %v", err)
+	}
+}
+
+func TestPullToStagingDir_CleanupRemovesTempDir(t *testing.T) {
+	parentDir := t.TempDir()
+
+	var capturedStagingDir string
+	_, cleanup, err := pullToStagingDir(parentDir, "cleanup-test", func(stagingDir string) error {
+		capturedStagingDir = stagingDir
+		return os.MkdirAll(filepath.Join(stagingDir, "cleanup-test"), 0o755)
+	})
+	if err != nil {
+		t.Fatalf("pullToStagingDir: %v", err)
+	}
+
+	cleanup()
+
+	if _, err := os.Stat(capturedStagingDir); !os.IsNotExist(err) {
+		t.Errorf("staging dir should be removed after cleanup, stat err = %v", err)
+	}
+}
+
+func TestPullToStagingDir_CleanupOnPullFailure(t *testing.T) {
+	parentDir := t.TempDir()
+
+	_, cleanup, err := pullToStagingDir(parentDir, "fail-test", func(stagingDir string) error {
+		if err := os.WriteFile(filepath.Join(stagingDir, "partial.txt"), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return fmt.Errorf("simulated pull failure")
+	})
+	if err == nil {
+		t.Fatal("expected error from failing pullFn")
+	}
+	if !strings.Contains(err.Error(), "simulated pull failure") {
+		t.Errorf("error should propagate: %v", err)
+	}
+
+	cleanup()
+
+	entries, readErr := os.ReadDir(parentDir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".staging-") {
+			t.Errorf("leftover staging dir after cleanup: %s", e.Name())
+		}
+	}
+}
+
+func TestPullToStagingDir_StaleFilesNotCarriedForward(t *testing.T) {
+	parentDir := t.TempDir()
+
+	staleDir := filepath.Join(parentDir, "my-artifact")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "stale.txt"), []byte("old"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	artifactDir, cleanup, err := pullToStagingDir(parentDir, "my-artifact", func(stagingDir string) error {
+		dest := filepath.Join(stagingDir, "my-artifact")
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "fresh.txt"), []byte("new"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("pullToStagingDir: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "fresh.txt")); err != nil {
+		t.Errorf("fresh.txt should exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(artifactDir, "stale.txt")); !os.IsNotExist(err) {
+		t.Errorf("stale.txt should NOT exist in staging dir, stat err = %v", err)
+	}
+}
+
+func TestPullToStagingDir_CreatesParentDirIfMissing(t *testing.T) {
+	parentDir := filepath.Join(t.TempDir(), "nested", "cache")
+
+	artifactDir, cleanup, err := pullToStagingDir(parentDir, "new-dir-test", func(stagingDir string) error {
+		dest := filepath.Join(stagingDir, "new-dir-test")
+		if err := os.MkdirAll(dest, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "file.txt"), []byte("ok"), 0o600)
+	})
+	if err != nil {
+		t.Fatalf("pullToStagingDir with missing parent: %v", err)
+	}
+	defer cleanup()
+
+	if _, err := os.Stat(filepath.Join(artifactDir, "file.txt")); err != nil {
+		t.Errorf("file.txt should exist: %v", err)
+	}
+}
+
+func TestPullToStagingDir_ConcurrentPullsGetSeparateDirs(t *testing.T) {
+	parentDir := t.TempDir()
+
+	type result struct {
+		artifactDir string
+		cleanup     func()
+		err         error
+	}
+
+	ch := make(chan result, 2)
+	for i := 0; i < 2; i++ {
+		marker := fmt.Sprintf("marker-%d", i)
+		go func() {
+			ad, cl, err := pullToStagingDir(parentDir, "concurrent", func(stagingDir string) error {
+				dest := filepath.Join(stagingDir, "concurrent")
+				if err := os.MkdirAll(dest, 0o755); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(dest, marker+".txt"), []byte(marker), 0o600)
+			})
+			ch <- result{ad, cl, err}
+		}()
+	}
+
+	var results []result
+	for i := 0; i < 2; i++ {
+		results = append(results, <-ch)
+	}
+	for _, r := range results {
+		if r.err != nil {
+			t.Fatalf("concurrent pullToStagingDir failed: %v", r.err)
+		}
+		defer r.cleanup()
+	}
+
+	if results[0].artifactDir == results[1].artifactDir {
+		t.Error("concurrent pulls should use different staging directories")
+	}
+
+	for i, r := range results {
+		entries, err := os.ReadDir(r.artifactDir)
+		if err != nil {
+			t.Fatalf("read artifactDir %d: %v", i, err)
+		}
+		if len(entries) != 1 {
+			t.Errorf("artifactDir %d should have exactly 1 file, got %d", i, len(entries))
+		}
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1566,3 +1566,26 @@ func TestPullToStagingDir_ConcurrentPullsGetSeparateDirs(t *testing.T) {
 		}
 	}
 }
+
+func TestPullToStagingDir_RejectsUnsafeArtifactNames(t *testing.T) {
+	parentDir := t.TempDir()
+	noop := func(string) error { return nil }
+
+	cases := []string{
+		"../escape",
+		"foo/bar",
+		"foo\\bar",
+		"..\\escape",
+		"a/../b",
+	}
+	for _, name := range cases {
+		_, cleanup, err := pullToStagingDir(parentDir, name, noop)
+		cleanup()
+		if err == nil {
+			t.Errorf("expected error for artifact name %q, got nil", name)
+		}
+		if err != nil && !strings.Contains(err.Error(), "unsafe artifact name") {
+			t.Errorf("error for %q should mention unsafe artifact name: %v", name, err)
+		}
+	}
+}

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -77,6 +77,9 @@ By default, artifacts are also stored under the Striatum cache (STRIATUM_HOME or
 
 			if noCache {
 				for i, r := range resolved {
+					if err := os.RemoveAll(filepath.Join(outputDir, r.Name)); err != nil {
+						return fmt.Errorf("clean output dir for %s: %w", r.Name, err)
+					}
 					if i == 0 {
 						if err := oci.Pull(ctx, target, ref, outputDir); err != nil {
 							return fmt.Errorf("pull %s@%s: %w", r.Name, r.Version, err)

--- a/internal/cli/pull.go
+++ b/internal/cli/pull.go
@@ -75,6 +75,10 @@ By default, artifacts are also stored under the Striatum cache (STRIATUM_HOME or
 				}
 			}
 
+			if err := validateResolvedPaths(resolved); err != nil {
+				return err
+			}
+
 			if noCache {
 				for i, r := range resolved {
 					if err := os.RemoveAll(filepath.Join(outputDir, r.Name)); err != nil {

--- a/internal/cli/pull_test.go
+++ b/internal/cli/pull_test.go
@@ -219,6 +219,115 @@ func TestPull_NoCache_WithDeps_TriesPullDependency(t *testing.T) {
 	}
 }
 
+func TestPull_CachedPath_StaleFilesNotInFinalCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	baseDir := t.TempDir()
+	layoutDir := t.TempDir()
+	outDir := t.TempDir()
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "stale-cached", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "SKILL.md"), []byte("# content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := oci.Pack(context.Background(), manifest, baseDir, layoutDir); err != nil {
+		t.Fatal(err)
+	}
+
+	cacheRoot := filepath.Join(home, "cache")
+	staleDir := filepath.Join(cacheRoot, "stale-cached")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "leftover.txt"), []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCommand()
+	root.SetOut(&strings.Builder{})
+	root.SetArgs([]string{"pull", "oci:" + layoutDir + ":stale-cached:1.0.0", "--output", outDir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("pull: %v", err)
+	}
+
+	cacheDir := installer.CacheDir("stale-cached", "1.0.0")
+	if _, err := os.Stat(filepath.Join(cacheDir, "artifact.json")); err != nil {
+		t.Errorf("artifact.json should exist in final cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md should exist in final cache: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(cacheDir, "leftover.txt")); !os.IsNotExist(err) {
+		t.Error("stale leftover.txt should NOT exist in final cache after cached pull")
+	}
+}
+
+func TestPull_NoCache_CleansStaleFiles(t *testing.T) {
+	t.Setenv("STRIATUM_HOME", t.TempDir())
+	baseDir := t.TempDir()
+	layoutDir := t.TempDir()
+	outDir := t.TempDir()
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "stale-test", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "SKILL.md"), []byte("# content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := oci.Pack(context.Background(), manifest, baseDir, layoutDir); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"pull", "--no-cache", "oci:" + layoutDir + ":stale-test:1.0.0", "--output", outDir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("first pull: %v", err)
+	}
+
+	staleFile := filepath.Join(outDir, "stale-test", "leftover.txt")
+	if err := os.WriteFile(staleFile, []byte("stale"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	root2 := NewRootCommand()
+	root2.SetArgs([]string{"pull", "--no-cache", "oci:" + layoutDir + ":stale-test:1.0.0", "--output", outDir})
+	if err := root2.Execute(); err != nil {
+		t.Fatalf("second pull: %v", err)
+	}
+
+	if _, err := os.Stat(staleFile); !os.IsNotExist(err) {
+		t.Error("stale file should be removed after re-pull")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "stale-test", "artifact.json")); err != nil {
+		t.Errorf("artifact.json should exist after re-pull: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "stale-test", "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md should exist after re-pull: %v", err)
+	}
+}
+
 func TestPull_NoCache_OutputOnly(t *testing.T) {
 	t.Setenv("STRIATUM_HOME", t.TempDir())
 	baseDir := t.TempDir()


### PR DESCRIPTION
Fixes #42

## Summary

- Add `pullToStagingDir` helper that creates a unique temp directory via `os.MkdirTemp` per pull, replacing the deterministic `cacheRoot/<name>` staging path
- Refactor all three cached-pull call sites (`ensureArtifactsInCache`, local install deps, `repullToCache`) to use it
- Pre-clean `outputDir/<name>` in the `--no-cache` pull path before each pull