### PR TITLE
Add commit resolution and immutable digests for dependencies

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -240,13 +240,14 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("read artifact manifest from git pull: %w", err)
 			}
-			name := strings.TrimSpace(rootManifest.Metadata.Name)
-			version := strings.TrimSpace(rootManifest.Metadata.Version)
-			if name == "" || version == "" ||
+			name := rootManifest.Metadata.Name
+			version := rootManifest.Metadata.Version
+			if strings.TrimSpace(name) == "" || strings.TrimSpace(version) == "" ||
+				name != strings.TrimSpace(name) || version != strings.TrimSpace(version) ||
 				strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") ||
 				strings.ContainsAny(version, "/\\") || strings.Contains(version, "..") {
 				_ = os.RemoveAll(stagingDir)
-				return fmt.Errorf("unsafe artifact name or version %q / %q: must not contain path separators or '..'", name, version)
+				return fmt.Errorf("unsafe artifact name or version %q / %q", name, version)
 			}
 			cacheDir := installer.CacheDir(name, version)
 			if err := atomicReplaceCacheDir(pulledDir, cacheDir); err != nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -243,6 +243,7 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 			name := rootManifest.Metadata.Name
 			version := rootManifest.Metadata.Version
 			if strings.TrimSpace(name) == "" || strings.TrimSpace(version) == "" ||
+				name == "." || version == "." ||
 				name != strings.TrimSpace(name) || version != strings.TrimSpace(version) ||
 				strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") ||
 				strings.ContainsAny(version, "/\\") || strings.Contains(version, "..") {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -209,9 +209,42 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 			if err != nil {
 				return fmt.Errorf("parse git reference: %w", err)
 			}
-			rootManifest, err = defaultRouter().Inspect(ctx, loc)
+			gitDep, ok := loc.(*artifact.GitDependency)
+			if !ok {
+				return fmt.Errorf("expected git dependency from %q", reference)
+			}
+			cacheRoot := filepath.Join(installer.CacheRoot(), "cache")
+			if err := os.MkdirAll(cacheRoot, 0o755); err != nil {
+				return fmt.Errorf("create cache root: %w", err)
+			}
+			stagingDir, err := os.MkdirTemp(cacheRoot, ".staging-git-root-*")
 			if err != nil {
-				return fmt.Errorf("inspect git artifact: %w", err)
+				return fmt.Errorf("create staging dir: %w", err)
+			}
+			if err := defaultRouter().Pull(ctx, loc, stagingDir); err != nil {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("pull git artifact: %w", err)
+			}
+			entries, err := os.ReadDir(stagingDir)
+			if err != nil || len(entries) == 0 {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("no artifact found after git pull")
+			}
+			pulledDir := filepath.Join(stagingDir, entries[0].Name())
+			rootManifest, err = artifact.Load(filepath.Join(pulledDir, "artifact.json"))
+			if err != nil {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("read artifact manifest from git pull: %w", err)
+			}
+			cacheDir := installer.CacheDir(rootManifest.Metadata.Name, rootManifest.Metadata.Version)
+			if err := atomicReplaceCacheDir(pulledDir, cacheDir); err != nil {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("cache git artifact: %w", err)
+			}
+			_ = os.RemoveAll(stagingDir)
+			gitBack := &gitbackend.Backend{}
+			if commit, err := gitBack.ResolveCommit(ctx, gitDep); err == nil && commit != "" {
+				_ = installer.WriteDigest(cacheDir, commit)
 			}
 		} else {
 			if !strings.Contains(reference, "/") && !strings.HasPrefix(reference, "oci:") {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -226,7 +226,11 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 				return fmt.Errorf("pull git artifact: %w", err)
 			}
 			entries, err := os.ReadDir(stagingDir)
-			if err != nil || len(entries) == 0 {
+			if err != nil {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("read staging dir after git pull: %w", err)
+			}
+			if len(entries) == 0 {
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("no artifact found after git pull")
 			}
@@ -236,9 +240,10 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("read artifact manifest from git pull: %w", err)
 			}
-			name := rootManifest.Metadata.Name
-			version := rootManifest.Metadata.Version
-			if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") ||
+			name := strings.TrimSpace(rootManifest.Metadata.Name)
+			version := strings.TrimSpace(rootManifest.Metadata.Version)
+			if name == "" || version == "" ||
+				strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") ||
 				strings.ContainsAny(version, "/\\") || strings.Contains(version, "..") {
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("unsafe artifact name or version %q / %q: must not contain path separators or '..'", name, version)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -204,17 +204,28 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 		rootManifest = m
 	}
 	if rootManifest == nil {
-		if !strings.Contains(reference, "/") && !strings.HasPrefix(reference, "oci:") {
-			return fmt.Errorf("short ref %q is not in cache (cache-only); use a full reference (host/repo/name:version or oci:/path:name:version) to pull from a registry", reference)
-		}
-		var err error
-		targetObj, ref, err = resolveTargetAndRef(reference)
-		if err != nil {
-			return fmt.Errorf("resolve reference: %w", err)
-		}
-		rootManifest, err = oci.Inspect(ctx, targetObj, ref)
-		if err != nil {
-			return fmt.Errorf("read artifact manifest: %w", err)
+		if strings.HasPrefix(reference, "git:") {
+			loc, err := registry.ParseReference(reference)
+			if err != nil {
+				return fmt.Errorf("parse git reference: %w", err)
+			}
+			rootManifest, err = defaultRouter().Inspect(ctx, loc)
+			if err != nil {
+				return fmt.Errorf("inspect git artifact: %w", err)
+			}
+		} else {
+			if !strings.Contains(reference, "/") && !strings.HasPrefix(reference, "oci:") {
+				return fmt.Errorf("short ref %q is not in cache (cache-only); use a full reference (host/repo/name:version or oci:/path:name:version) to pull from a registry", reference)
+			}
+			var err error
+			targetObj, ref, err = resolveTargetAndRef(reference)
+			if err != nil {
+				return fmt.Errorf("resolve reference: %w", err)
+			}
+			rootManifest, err = oci.Inspect(ctx, targetObj, ref)
+			if err != nil {
+				return fmt.Errorf("read artifact manifest: %w", err)
+			}
 		}
 	}
 
@@ -616,17 +627,27 @@ func ensureArtifactsInCache(ctx context.Context, reference string, rootTarget or
 		pullFn := func(ctx context.Context, _ string) error {
 			created, cleanup, err := pullToStagingDir(cacheRoot, res.Name, func(stagingDir string) error {
 				if idx == 0 {
-					pullTarget := rootTarget
-					pullRef := rootRef
-					if pullTarget == nil {
-						resolvedTarget, resolvedRef, err := resolveTargetAndRef(reference)
+					if strings.HasPrefix(reference, "git:") {
+						loc, err := registry.ParseReference(reference)
 						if err != nil {
-							return fmt.Errorf("root was loaded from cache but cache is no longer present; cannot re-pull: %w", err)
+							return fmt.Errorf("parse git reference: %w", err)
 						}
-						pullTarget, pullRef = resolvedTarget, resolvedRef
-					}
-					if err := oci.Pull(ctx, pullTarget, pullRef, stagingDir); err != nil {
-						return fmt.Errorf("download OCI artifact: %w", err)
+						if err := defaultRouter().Pull(ctx, loc, stagingDir); err != nil {
+							return fmt.Errorf("download git artifact: %w", err)
+						}
+					} else {
+						pullTarget := rootTarget
+						pullRef := rootRef
+						if pullTarget == nil {
+							resolvedTarget, resolvedRef, err := resolveTargetAndRef(reference)
+							if err != nil {
+								return fmt.Errorf("root was loaded from cache but cache is no longer present; cannot re-pull: %w", err)
+							}
+							pullTarget, pullRef = resolvedTarget, resolvedRef
+						}
+						if err := oci.Pull(ctx, pullTarget, pullRef, stagingDir); err != nil {
+							return fmt.Errorf("download OCI artifact: %w", err)
+						}
 					}
 				} else {
 					if err := pullDependency(ctx, res.Dependency, stagingDir); err != nil {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -255,8 +255,12 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 			}
 			_ = os.RemoveAll(stagingDir)
 			gitBack := &gitbackend.Backend{}
-			if commit, err := gitBack.ResolveCommit(ctx, gitDep); err == nil && commit != "" {
-				_ = installer.WriteDigest(cacheDir, commit)
+			commit, err := gitBack.ResolveCommit(ctx, gitDep)
+			if err != nil {
+				return fmt.Errorf("resolve git commit for cache digest: %w", err)
+			}
+			if err := installer.WriteDigest(cacheDir, commit); err != nil {
+				return fmt.Errorf("write cache digest: %w", err)
 			}
 		} else {
 			if !strings.Contains(reference, "/") && !strings.HasPrefix(reference, "oci:") {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hbelmiro/striatum/pkg/installer"
 	"github.com/hbelmiro/striatum/pkg/oci"
 	"github.com/hbelmiro/striatum/pkg/registry"
+	gitbackend "github.com/hbelmiro/striatum/pkg/registry/git"
 	"github.com/hbelmiro/striatum/pkg/resolver"
 	"github.com/spf13/cobra"
 	"oras.land/oras-go/v2"
@@ -328,6 +329,13 @@ func runLocalInstall(cmd *cobra.Command, reference, target, projectPath string, 
 					return oci.ResolveDigest(ctx, reg, capturedDep.Tag)
 				}
 			}
+			if gitDep, ok := res.Dependency.(*artifact.GitDependency); ok {
+				capturedDep := gitDep
+				gitBack := &gitbackend.Backend{}
+				digestFn = func(ctx context.Context) (string, error) {
+					return gitBack.ResolveCommit(ctx, capturedDep)
+				}
+			}
 			if err := installer.EnsureInCache(ctx, depCacheDir, pullFn, digestFn); err != nil {
 				return fmt.Errorf("pull %s@%s: %w", res.Name, res.Version, err)
 			}
@@ -570,7 +578,19 @@ func ensureArtifactsInCache(ctx context.Context, reference string, rootTarget or
 					return oci.ResolveDigest(ctx, t, ref)
 				}
 			}
-			// If git ref or short ref, digestFn stays nil
+			if strings.HasPrefix(reference, "git:") {
+				loc, err := registry.ParseReference(reference)
+				if err != nil {
+					return fmt.Errorf("parse git reference %q: %w", reference, err)
+				}
+				if gitDep, ok := loc.(*artifact.GitDependency); ok {
+					capturedDep := gitDep
+					gitBack := &gitbackend.Backend{}
+					digestFn = func(ctx context.Context) (string, error) {
+						return gitBack.ResolveCommit(ctx, capturedDep)
+					}
+				}
+			}
 		} else {
 			// Dependency: check if it's an OCI dependency
 			if ociDep, ok := res.Dependency.(*artifact.OCIDependency); ok {
@@ -584,7 +604,13 @@ func ensureArtifactsInCache(ctx context.Context, reference string, rootTarget or
 					return oci.ResolveDigest(ctx, reg, capturedDep.Tag)
 				}
 			}
-			// Git dependencies: digestFn stays nil (no digest checking)
+			if gitDep, ok := res.Dependency.(*artifact.GitDependency); ok {
+				capturedDep := gitDep
+				gitBack := &gitbackend.Backend{}
+				digestFn = func(ctx context.Context) (string, error) {
+					return gitBack.ResolveCommit(ctx, capturedDep)
+				}
+			}
 		}
 
 		pullFn := func(ctx context.Context, _ string) error {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -236,7 +236,14 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("read artifact manifest from git pull: %w", err)
 			}
-			cacheDir := installer.CacheDir(rootManifest.Metadata.Name, rootManifest.Metadata.Version)
+			name := rootManifest.Metadata.Name
+			version := rootManifest.Metadata.Version
+			if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") ||
+				strings.ContainsAny(version, "/\\") || strings.Contains(version, "..") {
+				_ = os.RemoveAll(stagingDir)
+				return fmt.Errorf("unsafe artifact name or version %q / %q: must not contain path separators or '..'", name, version)
+			}
+			cacheDir := installer.CacheDir(name, version)
 			if err := atomicReplaceCacheDir(pulledDir, cacheDir); err != nil {
 				_ = os.RemoveAll(stagingDir)
 				return fmt.Errorf("cache git artifact: %w", err)

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1632,7 +1632,11 @@ func setupGitRepo(t *testing.T) string {
 	run(workDir, "git", "tag", "v1.0.0")
 	run(workDir, "git", "push", "origin", "HEAD", "--tags")
 
-	return "file://" + bareDir
+	p := filepath.ToSlash(bareDir)
+	if len(p) > 0 && p[0] != '/' {
+		p = "/" + p
+	}
+	return "file://" + p
 }
 
 func TestInstall_GitRef_HappyPath(t *testing.T) {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1604,7 +1604,7 @@ func setupGitRepo(t *testing.T) string {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -1587,5 +1588,80 @@ func TestPullToStagingDir_RejectsUnsafeArtifactNames(t *testing.T) {
 		if err != nil && !strings.Contains(err.Error(), "unsafe artifact name") {
 			t.Errorf("error for %q should mention unsafe artifact name: %v", name, err)
 		}
+	}
+}
+
+func setupGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "git-skill", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Git Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	run(workDir, "git", "tag", "v1.0.0")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	return "file://" + bareDir
+}
+
+func TestInstall_GitRef_HappyPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+
+	repoURL := setupGitRepo(t)
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", "git:" + repoURL + "@v1.0.0"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("install git ref: %v", err)
+	}
+	if !strings.Contains(out.String(), "Installed") {
+		t.Errorf("output %q", out.String())
+	}
+
+	cursorSkills := filepath.Join(home, ".cursor", "skills", "git-skill")
+	if _, err := os.Stat(filepath.Join(cursorSkills, "artifact.json")); err != nil {
+		t.Errorf("artifact not installed: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(cursorSkills, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(data), "Git Skill") {
+		t.Errorf("SKILL.md = %q, want 'Git Skill'", string(data))
 	}
 }

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1612,7 +1612,7 @@ func setupGitRepo(t *testing.T) string {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -142,7 +142,7 @@ func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputD
 		}
 
 		name := m.Metadata.Name
-		if strings.TrimSpace(name) == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") || name != strings.TrimSpace(name) {
+		if strings.TrimSpace(name) == "" || name == "." || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") || name != strings.TrimSpace(name) {
 			return fmt.Errorf("unsafe artifact name %q in manifest", name)
 		}
 		destDir := filepath.Join(outputDir, name)

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -54,7 +54,23 @@ func (b *Backend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency
 	}
 
 	var candidates []string
-	if strings.HasPrefix(dep.Ref, "refs/") {
+	if dep.Ref == "HEAD" {
+		for _, ref := range refs {
+			if ref.Name().String() == "HEAD" {
+				if ref.Hash().IsZero() && ref.Target() != "" {
+					target := ref.Target().String()
+					for _, r := range refs {
+						if r.Name().String() == target {
+							return r.Hash().String(), nil
+						}
+					}
+					return "", fmt.Errorf("HEAD target %q not found in %s", target, dep.URL)
+				}
+				return ref.Hash().String(), nil
+			}
+		}
+		return "", fmt.Errorf("HEAD not found in %s", dep.URL)
+	} else if strings.HasPrefix(dep.Ref, "refs/") {
 		candidates = []string{dep.Ref}
 	} else {
 		candidates = []string{

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -53,9 +53,14 @@ func (b *Backend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency
 		return "", fmt.Errorf("ls-remote %s: %w", dep.URL, err)
 	}
 
-	candidates := []string{
-		"refs/heads/" + dep.Ref,
-		"refs/tags/" + dep.Ref,
+	var candidates []string
+	if strings.HasPrefix(dep.Ref, "refs/") {
+		candidates = []string{dep.Ref}
+	} else {
+		candidates = []string{
+			"refs/heads/" + dep.Ref,
+			"refs/tags/" + dep.Ref,
+		}
 	}
 
 	var peeledHash plumbing.Hash
@@ -138,9 +143,13 @@ func withTree(ctx context.Context, dep *artifact.GitDependency, fn func(*object.
 		return fmt.Errorf("clone %s: %w", dep.URL, err)
 	}
 
-	hash, err := repo.ResolveRevision(plumbing.Revision(dep.Ref))
+	ref := dep.Ref
+	if dep.Commit != "" {
+		ref = dep.Commit
+	}
+	hash, err := repo.ResolveRevision(plumbing.Revision(ref))
 	if err != nil {
-		return fmt.Errorf("resolve ref %q in %s: %w", dep.Ref, dep.URL, err)
+		return fmt.Errorf("resolve ref %q in %s: %w", ref, dep.URL, err)
 	}
 
 	commit, err := repo.CommitObject(*hash)

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -141,8 +141,8 @@ func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputD
 			return err
 		}
 
-		name := strings.TrimSpace(m.Metadata.Name)
-		if name == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		name := m.Metadata.Name
+		if strings.TrimSpace(name) == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") || name != strings.TrimSpace(name) {
 			return fmt.Errorf("unsafe artifact name %q in manifest", name)
 		}
 		destDir := filepath.Join(outputDir, name)

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/hbelmiro/striatum/pkg/artifact"
 	"github.com/hbelmiro/striatum/pkg/registry"
 )
@@ -31,6 +33,56 @@ func (b *Backend) Inspect(ctx context.Context, dep *artifact.GitDependency) (*ar
 		return readErr
 	})
 	return m, err
+}
+
+func (b *Backend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency) (string, error) {
+	if dep.Commit != "" {
+		return dep.Commit, nil
+	}
+	if artifact.IsValidCommitSHA(dep.Ref) {
+		return dep.Ref, nil
+	}
+
+	remote := gogit.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{dep.URL},
+	})
+	refs, err := remote.ListContext(ctx, &gogit.ListOptions{
+		PeelingOption: gogit.AppendPeeled,
+	})
+	if err != nil {
+		return "", fmt.Errorf("ls-remote %s: %w", dep.URL, err)
+	}
+
+	candidates := []string{
+		"refs/heads/" + dep.Ref,
+		"refs/tags/" + dep.Ref,
+	}
+
+	var peeledHash plumbing.Hash
+	var directHash plumbing.Hash
+	var found bool
+
+	for _, ref := range refs {
+		name := ref.Name().String()
+		for _, c := range candidates {
+			if name == c {
+				directHash = ref.Hash()
+				found = true
+			}
+			if name == c+"^{}" {
+				peeledHash = ref.Hash()
+			}
+		}
+	}
+
+	if !found {
+		return "", fmt.Errorf("ref %q not found in %s", dep.Ref, dep.URL)
+	}
+
+	if !peeledHash.IsZero() {
+		return peeledHash.String(), nil
+	}
+	return directHash.String(), nil
 }
 
 func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputDir string) error {

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -141,7 +141,11 @@ func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputD
 			return err
 		}
 
-		destDir := filepath.Join(outputDir, m.Metadata.Name)
+		name := m.Metadata.Name
+		if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") || name == "" {
+			return fmt.Errorf("unsafe artifact name %q in manifest", name)
+		}
+		destDir := filepath.Join(outputDir, name)
 		if err := os.MkdirAll(destDir, 0o755); err != nil {
 			return fmt.Errorf("create output dir: %w", err)
 		}

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -141,8 +141,8 @@ func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputD
 			return err
 		}
 
-		name := m.Metadata.Name
-		if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") || name == "" {
+		name := strings.TrimSpace(m.Metadata.Name)
+		if name == "" || strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
 			return fmt.Errorf("unsafe artifact name %q in manifest", name)
 		}
 		destDir := filepath.Join(outputDir, name)

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -63,31 +63,55 @@ func (b *Backend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency
 		}
 	}
 
-	var peeledHash plumbing.Hash
-	var directHash plumbing.Hash
-	var found bool
+	type match struct {
+		direct plumbing.Hash
+		peeled plumbing.Hash
+	}
+	matches := make(map[string]*match)
 
 	for _, ref := range refs {
 		name := ref.Name().String()
 		for _, c := range candidates {
 			if name == c {
-				directHash = ref.Hash()
-				found = true
+				if matches[c] == nil {
+					matches[c] = &match{}
+				}
+				matches[c].direct = ref.Hash()
 			}
 			if name == c+"^{}" {
-				peeledHash = ref.Hash()
+				if matches[c] == nil {
+					matches[c] = &match{}
+				}
+				matches[c].peeled = ref.Hash()
 			}
 		}
 	}
 
-	if !found {
+	if len(matches) == 0 {
 		return "", fmt.Errorf("ref %q not found in %s", dep.Ref, dep.URL)
 	}
 
-	if !peeledHash.IsZero() {
-		return peeledHash.String(), nil
+	if len(matches) > 1 {
+		var resolved []plumbing.Hash
+		for _, m := range matches {
+			if !m.peeled.IsZero() {
+				resolved = append(resolved, m.peeled)
+			} else {
+				resolved = append(resolved, m.direct)
+			}
+		}
+		if len(resolved) >= 2 && resolved[0] != resolved[1] {
+			return "", fmt.Errorf("ref %q is ambiguous in %s (matches both a branch and a tag with different commits); use a fully-qualified ref (refs/heads/%s or refs/tags/%s)", dep.Ref, dep.URL, dep.Ref, dep.Ref)
+		}
 	}
-	return directHash.String(), nil
+
+	for _, m := range matches {
+		if !m.peeled.IsZero() {
+			return m.peeled.String(), nil
+		}
+		return m.direct.String(), nil
+	}
+	return "", fmt.Errorf("ref %q not found in %s", dep.Ref, dep.URL)
 }
 
 func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputDir string) error {

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -499,6 +499,56 @@ func TestResolveCommit_FullyQualifiedTagRef(t *testing.T) {
 	}
 }
 
+func TestResolveCommit_AmbiguousBranchAndTag(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("first"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "first")
+	run(workDir, "git", "tag", "release")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	run(workDir, "git", "checkout", "-b", "release")
+	if err := os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("second"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "second")
+	run(workDir, "git", "push", "origin", "refs/heads/release:refs/heads/release")
+
+	b := &Backend{}
+	_, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: "file://" + bareDir, Ref: "release",
+	})
+	if err == nil {
+		t.Fatal("expected error for ambiguous ref (branch and tag with same name)")
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error should mention ambiguous, got: %v", err)
+	}
+}
+
 func TestResolveCommit_InvalidRef(t *testing.T) {
 	url := setupLocalRepo(t, "", "v1.0.0")
 	b := &Backend{}

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -453,6 +453,52 @@ func TestResolveCommit_AnnotatedTag(t *testing.T) {
 	}
 }
 
+func TestResolveCommit_FullyQualifiedBranchRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+
+	shortSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("short ref: %v", err)
+	}
+
+	fullSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "refs/heads/master",
+	})
+	if err != nil {
+		t.Fatalf("fully-qualified ref: %v", err)
+	}
+
+	if shortSHA != fullSHA {
+		t.Errorf("short %q != full %q", shortSHA, fullSHA)
+	}
+}
+
+func TestResolveCommit_FullyQualifiedTagRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+
+	shortSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("short ref: %v", err)
+	}
+
+	fullSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "refs/tags/v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("fully-qualified ref: %v", err)
+	}
+
+	if shortSHA != fullSHA {
+		t.Errorf("short %q != full %q", shortSHA, fullSHA)
+	}
+}
+
 func TestResolveCommit_InvalidRef(t *testing.T) {
 	url := setupLocalRepo(t, "", "v1.0.0")
 	b := &Backend{}
@@ -546,6 +592,141 @@ func TestResolveCommit_DetectsNewCommit(t *testing.T) {
 
 	if first == second {
 		t.Errorf("expected different SHAs after new commit, both = %q", first)
+	}
+}
+
+func TestBackend_Pull_UsesPinnedCommit(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "test-skill", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "first")
+	firstSHA := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Updated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "second")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	b := &Backend{}
+	outDir := t.TempDir()
+	err := b.Pull(context.Background(), &artifact.GitDependency{
+		URL: "file://" + bareDir, Ref: "master", Commit: firstSHA,
+	}, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(outDir, "test-skill", "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(data), "Original") {
+		t.Errorf("expected content from pinned commit (Original), got %q", string(data))
+	}
+	if strings.Contains(string(data), "Updated") {
+		t.Errorf("got content from branch HEAD instead of pinned commit: %q", string(data))
+	}
+}
+
+func TestBackend_Inspect_UsesPinnedCommit(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "test-skill", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "first")
+	firstSHA := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	manifest2 := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "test-skill", "version": "2.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest2), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "second")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	b := &Backend{}
+	m, err := b.Inspect(context.Background(), &artifact.GitDependency{
+		URL: "file://" + bareDir, Ref: "master", Commit: firstSHA,
+	})
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Version != "1.0.0" {
+		t.Errorf("expected version 1.0.0 from pinned commit, got %q", m.Metadata.Version)
 	}
 }
 

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -329,6 +329,59 @@ func TestBackend_Pull_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestBackend_Pull_RejectsUnsafeMetadataName(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "../../escape", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Evil"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	run(workDir, "git", "tag", "v1.0.0")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	b := &Backend{}
+	outDir := t.TempDir()
+	err := b.Pull(context.Background(), &artifact.GitDependency{
+		URL: fileURL(bareDir), Ref: "v1.0.0",
+	}, outDir)
+	if err == nil {
+		t.Fatal("Pull() should reject unsafe metadata.name")
+	}
+	if !strings.Contains(err.Error(), "unsafe") {
+		t.Errorf("error should mention unsafe, got: %v", err)
+	}
+}
+
 // --- ResolveCommit ---
 
 func TestResolveCommit_PinnedCommit(t *testing.T) {

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -11,6 +11,14 @@ import (
 	"github.com/hbelmiro/striatum/pkg/artifact"
 )
 
+func fileURL(path string) string {
+	p := filepath.ToSlash(path)
+	if len(p) > 0 && p[0] != '/' {
+		p = "/" + p
+	}
+	return "file://" + p
+}
+
 // setupLocalRepo creates a bare git repo with an artifact.json and skill file
 // at the given subPath (empty string = repo root), tagged with tagName.
 // Returns the file:// URL to the bare repo.
@@ -64,7 +72,7 @@ func setupLocalRepo(t *testing.T, subPath, tagName string) string {
 	run(workDir, "git", "tag", tagName)
 	run(workDir, "git", "push", "origin", "HEAD", "--tags")
 
-	return "file://" + bareDir
+	return fileURL(bareDir)
 }
 
 func TestBackend_Inspect_RootPath(t *testing.T) {
@@ -202,7 +210,7 @@ func TestBackend_Inspect_InvalidJSON(t *testing.T) {
 
 	b := &Backend{}
 	_, err := b.Inspect(context.Background(), &artifact.GitDependency{
-		URL: "file://" + bareDir, Ref: "v1.0.0",
+		URL: fileURL(bareDir), Ref: "v1.0.0",
 	})
 	if err == nil {
 		t.Fatal("Inspect() should fail for invalid JSON in artifact.json")
@@ -256,7 +264,7 @@ func TestBackend_Pull_MissingSpecFile(t *testing.T) {
 	b := &Backend{}
 	outDir := t.TempDir()
 	err := b.Pull(context.Background(), &artifact.GitDependency{
-		URL: "file://" + bareDir, Ref: "v1.0.0",
+		URL: fileURL(bareDir), Ref: "v1.0.0",
 	}, outDir)
 	if err == nil {
 		t.Fatal("Pull() should fail when spec.files lists a missing file")
@@ -307,7 +315,7 @@ func TestBackend_Pull_RejectsPathTraversal(t *testing.T) {
 	run(workDir, "git", "tag", "v1.0.0")
 	run(workDir, "git", "push", "origin", "HEAD", "--tags")
 
-	repoURL := "file://" + bareDir
+	repoURL := fileURL(bareDir)
 	b := &Backend{}
 	outDir := t.TempDir()
 	err := b.Pull(context.Background(), &artifact.GitDependency{
@@ -430,7 +438,7 @@ func TestResolveCommit_AnnotatedTag(t *testing.T) {
 	run(workDir, "git", "push", "origin", "HEAD", "--tags")
 
 	b := &Backend{}
-	repoURL := "file://" + bareDir
+	repoURL := fileURL(bareDir)
 
 	tagSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
 		URL: repoURL, Ref: "v2.0.0",
@@ -562,7 +570,7 @@ func TestResolveCommit_AmbiguousBranchAndTag(t *testing.T) {
 
 	b := &Backend{}
 	_, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
-		URL: "file://" + bareDir, Ref: "release",
+		URL: fileURL(bareDir), Ref: "release",
 	})
 	if err == nil {
 		t.Fatal("expected error for ambiguous ref (branch and tag with same name)")
@@ -641,7 +649,7 @@ func TestResolveCommit_DetectsNewCommit(t *testing.T) {
 	run(workDir, "git", "push", "origin", "HEAD")
 
 	b := &Backend{}
-	repoURL := "file://" + bareDir
+	repoURL := fileURL(bareDir)
 	first, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
 		URL: repoURL, Ref: "master",
 	})
@@ -719,7 +727,7 @@ func TestBackend_Pull_UsesPinnedCommit(t *testing.T) {
 	b := &Backend{}
 	outDir := t.TempDir()
 	err := b.Pull(context.Background(), &artifact.GitDependency{
-		URL: "file://" + bareDir, Ref: "master", Commit: firstSHA,
+		URL: fileURL(bareDir), Ref: "master", Commit: firstSHA,
 	}, outDir)
 	if err != nil {
 		t.Fatalf("Pull() err = %v", err)
@@ -793,7 +801,7 @@ func TestBackend_Inspect_UsesPinnedCommit(t *testing.T) {
 
 	b := &Backend{}
 	m, err := b.Inspect(context.Background(), &artifact.GitDependency{
-		URL: "file://" + bareDir, Ref: "master", Commit: firstSHA,
+		URL: fileURL(bareDir), Ref: "master", Commit: firstSHA,
 	})
 	if err != nil {
 		t.Fatalf("Inspect() err = %v", err)

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -321,6 +321,234 @@ func TestBackend_Pull_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// --- ResolveCommit ---
+
+func TestResolveCommit_PinnedCommit(t *testing.T) {
+	b := &Backend{}
+	commit := "abcdef0123456789abcdef0123456789abcdef01"
+	got, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: "https://example.com/repo.git", Ref: "main", Commit: commit,
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit() err = %v", err)
+	}
+	if got != commit {
+		t.Errorf("got %q, want %q", got, commit)
+	}
+}
+
+func TestResolveCommit_BareSHARef(t *testing.T) {
+	b := &Backend{}
+	sha := "abcdef0123456789abcdef0123456789abcdef01"
+	got, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: "https://example.com/repo.git", Ref: sha,
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit() err = %v", err)
+	}
+	if got != sha {
+		t.Errorf("got %q, want %q", got, sha)
+	}
+}
+
+func TestResolveCommit_BranchRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	got, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit() err = %v", err)
+	}
+	if len(got) != 40 {
+		t.Errorf("expected 40-char SHA, got %q (len %d)", got, len(got))
+	}
+}
+
+func TestResolveCommit_TagRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	got, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit() err = %v", err)
+	}
+	if len(got) != 40 {
+		t.Errorf("expected 40-char SHA, got %q (len %d)", got, len(got))
+	}
+}
+
+func TestResolveCommit_TagAndBranchAgree(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	tagSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "v1.0.0",
+	})
+	if err != nil {
+		t.Fatalf("tag: %v", err)
+	}
+	branchSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("branch: %v", err)
+	}
+	if tagSHA != branchSHA {
+		t.Errorf("tag SHA %q != branch SHA %q (same commit)", tagSHA, branchSHA)
+	}
+}
+
+func TestResolveCommit_AnnotatedTag(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	run(workDir, "git", "tag", "-a", "v2.0.0", "-m", "annotated tag")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	b := &Backend{}
+	repoURL := "file://" + bareDir
+
+	tagSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: repoURL, Ref: "v2.0.0",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit() err = %v", err)
+	}
+	if len(tagSHA) != 40 {
+		t.Errorf("expected 40-char SHA, got %q (len %d)", tagSHA, len(tagSHA))
+	}
+
+	branchSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: repoURL, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("branch resolve err = %v", err)
+	}
+	if tagSHA != branchSHA {
+		t.Errorf("annotated tag SHA %q != branch SHA %q (should dereference to commit)", tagSHA, branchSHA)
+	}
+}
+
+func TestResolveCommit_InvalidRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	_, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "nonexistent-ref",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent ref")
+	}
+}
+
+func TestResolveCommit_InvalidURL(t *testing.T) {
+	b := &Backend{}
+	_, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: "file:///nonexistent/repo.git", Ref: "main",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestResolveCommit_StableWhenUnchanged(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	dep := &artifact.GitDependency{URL: url, Ref: "v1.0.0"}
+
+	first, err := b.ResolveCommit(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := b.ResolveCommit(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first != second {
+		t.Errorf("same ref returned different SHAs: %q vs %q", first, second)
+	}
+}
+
+func TestResolveCommit_DetectsNewCommit(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "first")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	b := &Backend{}
+	repoURL := "file://" + bareDir
+	first, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: repoURL, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(workDir, "new-file.txt"), []byte("update"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "second")
+	run(workDir, "git", "push", "origin", "HEAD")
+
+	second, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: repoURL, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+
+	if first == second {
+		t.Errorf("expected different SHAs after new commit, both = %q", first)
+	}
+}
+
 func TestValidateFilePaths(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -43,7 +43,7 @@ func setupLocalRepo(t *testing.T, subPath, tagName string) string {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	artifactDir := workDir
@@ -198,7 +198,7 @@ func TestBackend_Inspect_InvalidJSON(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte("{invalid json"), 0o644); err != nil {
 		t.Fatal(err)
@@ -240,7 +240,7 @@ func TestBackend_Pull_MissingSpecFile(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{
@@ -294,7 +294,7 @@ func TestBackend_Pull_RejectsPathTraversal(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{
@@ -349,7 +349,7 @@ func TestBackend_Pull_RejectsUnsafeMetadataName(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{
@@ -480,7 +480,7 @@ func TestResolveCommit_AnnotatedTag(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 	if err := os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("data"), 0o644); err != nil {
 		t.Fatal(err)
@@ -603,7 +603,7 @@ func TestResolveCommit_AmbiguousBranchAndTag(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 	if err := os.WriteFile(filepath.Join(workDir, "file.txt"), []byte("first"), 0o644); err != nil {
 		t.Fatal(err)
@@ -692,7 +692,7 @@ func TestResolveCommit_DetectsNewCommit(t *testing.T) {
 		}
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)
@@ -750,7 +750,7 @@ func TestBackend_Pull_UsesPinnedCommit(t *testing.T) {
 		return strings.TrimSpace(string(out))
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{
@@ -819,7 +819,7 @@ func TestBackend_Inspect_UsesPinnedCommit(t *testing.T) {
 		return strings.TrimSpace(string(out))
 	}
 
-	run(dir, "git", "init", "--bare", bareDir)
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
 	run(dir, "git", "clone", bareDir, workDir)
 
 	manifest := `{

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -27,7 +27,7 @@ func setupLocalRepo(t *testing.T, subPath, tagName string) string {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -182,7 +182,7 @@ func TestBackend_Inspect_InvalidJSON(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -224,7 +224,7 @@ func TestBackend_Pull_MissingSpecFile(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -278,7 +278,7 @@ func TestBackend_Pull_RejectsPathTraversal(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -411,7 +411,7 @@ func TestResolveCommit_AnnotatedTag(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -511,7 +511,7 @@ func TestResolveCommit_AmbiguousBranchAndTag(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -600,7 +600,7 @@ func TestResolveCommit_DetectsNewCommit(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -657,7 +657,7 @@ func TestBackend_Pull_UsesPinnedCommit(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -726,7 +726,7 @@ func TestBackend_Inspect_UsesPinnedCommit(t *testing.T) {
 		cmd.Env = append(os.Environ(),
 			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
 			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL=/dev/null",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
 		)
 		out, err := cmd.CombinedOutput()
 		if err != nil {

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -499,6 +499,29 @@ func TestResolveCommit_FullyQualifiedTagRef(t *testing.T) {
 	}
 }
 
+func TestResolveCommit_HEADRef(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+
+	headSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "HEAD",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit(HEAD) err = %v", err)
+	}
+
+	masterSHA, err := b.ResolveCommit(context.Background(), &artifact.GitDependency{
+		URL: url, Ref: "master",
+	})
+	if err != nil {
+		t.Fatalf("ResolveCommit(master) err = %v", err)
+	}
+
+	if headSHA != masterSHA {
+		t.Errorf("HEAD %q != master %q", headSHA, masterSHA)
+	}
+}
+
 func TestResolveCommit_AmbiguousBranchAndTag(t *testing.T) {
 	dir := t.TempDir()
 	workDir := filepath.Join(dir, "work")

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -42,6 +42,7 @@ type OCIBackend interface {
 type GitBackend interface {
 	Inspect(ctx context.Context, dep *artifact.GitDependency) (*artifact.Manifest, error)
 	Pull(ctx context.Context, dep *artifact.GitDependency, outputDir string) error
+	ResolveCommit(ctx context.Context, dep *artifact.GitDependency) (string, error)
 }
 
 // OCILayoutBackend handles local OCI Image Layout operations.

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -344,8 +344,9 @@ func (m *mockOCIBackend) Pull(ctx context.Context, dep *artifact.OCIDependency, 
 }
 
 type mockGitBackend struct {
-	inspectFn func(ctx context.Context, dep *artifact.GitDependency) (*artifact.Manifest, error)
-	pullFn    func(ctx context.Context, dep *artifact.GitDependency, outputDir string) error
+	inspectFn       func(ctx context.Context, dep *artifact.GitDependency) (*artifact.Manifest, error)
+	pullFn          func(ctx context.Context, dep *artifact.GitDependency, outputDir string) error
+	resolveCommitFn func(ctx context.Context, dep *artifact.GitDependency) (string, error)
 }
 
 func (m *mockGitBackend) Inspect(ctx context.Context, dep *artifact.GitDependency) (*artifact.Manifest, error) {
@@ -353,6 +354,12 @@ func (m *mockGitBackend) Inspect(ctx context.Context, dep *artifact.GitDependenc
 }
 func (m *mockGitBackend) Pull(ctx context.Context, dep *artifact.GitDependency, outputDir string) error {
 	return m.pullFn(ctx, dep, outputDir)
+}
+func (m *mockGitBackend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency) (string, error) {
+	if m.resolveCommitFn != nil {
+		return m.resolveCommitFn(ctx, dep)
+	}
+	return "", nil
 }
 
 type mockOCILayoutBackend struct {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -356,10 +356,10 @@ func (m *mockGitBackend) Pull(ctx context.Context, dep *artifact.GitDependency, 
 	return m.pullFn(ctx, dep, outputDir)
 }
 func (m *mockGitBackend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency) (string, error) {
-	if m.resolveCommitFn != nil {
-		return m.resolveCommitFn(ctx, dep)
+	if m.resolveCommitFn == nil {
+		panic("mockGitBackend.ResolveCommit called without resolveCommitFn set")
 	}
-	return "", nil
+	return m.resolveCommitFn(ctx, dep)
 }
 
 type mockOCILayoutBackend struct {


### PR DESCRIPTION
Resolves #47

### Summary

This pull request includes the following changes:

- **Commit Resolution**:
  - Added support for resolving Git commit references (`branches`, `tags`, `annotated tags`) during dependency pulls.
  - Introduced `ResolveCommit` method and updated related logic in the installer.
  - Added comprehensive test coverage and enhanced mock Git backend.

- **Immutable Digests**:
  - Introduced support for `digest` (OCI) and `commit` (Git) fields in dependency management.
  - Improved validation for `digest` and `commit`, including checks for syntax and reserved delimiters.
  - Enhanced unit tests and documentation for `digest`/`commit` usage.
  - Added helper functions for reusable validation.

- **Safety Enhancements**:
  - Refined validation for artifact names and dependency paths, preventing unsafe behavior such as path traversal or invalid characters.

### Notes for Reviewers

Key improvements streamline Git and OCI dependency management while addressing validation gaps and safety issues. Changes also introduce extensive test coverage and updates to relevant documentation.