### PR TITLE
Add Git and OCI artifact inspection with enhanced validation

### DIFF
--- a/internal/cli/git_test_helpers_test.go
+++ b/internal/cli/git_test_helpers_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -42,12 +44,13 @@ func setupLocalGitRepo(t *testing.T, subPath, tagName string) string {
 		}
 	}
 
-	manifest := `{
+	version := strings.TrimPrefix(tagName, "v")
+	manifest := fmt.Sprintf(`{
   "apiVersion": "striatum.dev/v1alpha2",
   "kind": "Skill",
-  "metadata": {"name": "git-skill", "version": "1.0.0"},
+  "metadata": {"name": "git-skill", "version": %q},
   "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
-}`
+}`, version)
 	if err := os.WriteFile(filepath.Join(artifactDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/git_test_helpers_test.go
+++ b/internal/cli/git_test_helpers_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// setupLocalGitRepo creates a bare git repo with an artifact.json and skill file
+// at the given subPath (empty string = repo root), tagged with tagName.
+// Returns the file:// URL to the bare repo.
+func setupLocalGitRepo(t *testing.T, subPath, tagName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	artifactDir := workDir
+	if subPath != "" {
+		artifactDir = filepath.Join(workDir, subPath)
+		if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "git-skill", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(artifactDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "SKILL.md"), []byte("# Git Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	run(workDir, "git", "tag", tagName)
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	p := filepath.ToSlash(bareDir)
+	if len(p) > 0 && p[0] != '/' {
+		p = "/" + p
+	}
+	return "file://" + p
+}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -41,7 +41,11 @@ func inspectOCI(cmd *cobra.Command, reference string) error {
 			return fmt.Errorf("resolve digest: %w", err)
 		}
 	}
-	m, err := oci.Inspect(cmd.Context(), target, ref)
+	inspectRef := ref
+	if digest != "" {
+		inspectRef = digest
+	}
+	m, err := oci.Inspect(cmd.Context(), target, inspectRef)
 	if err != nil {
 		return fmt.Errorf("inspect artifact manifest and metadata: %w", err)
 	}

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -31,17 +31,19 @@ func newInspectCmd() *cobra.Command {
 }
 
 func inspectOCI(cmd *cobra.Command, reference string) error {
-	target, ref, _, err := resolveTargetAndRef(reference)
+	target, ref, digest, err := resolveTargetAndRef(reference)
 	if err != nil {
 		return fmt.Errorf("resolve reference: %w", err)
+	}
+	if digest == "" {
+		digest, err = oci.ResolveDigest(cmd.Context(), target, ref)
+		if err != nil {
+			return fmt.Errorf("resolve digest: %w", err)
+		}
 	}
 	m, err := oci.Inspect(cmd.Context(), target, ref)
 	if err != nil {
 		return fmt.Errorf("inspect artifact manifest and metadata: %w", err)
-	}
-	digest, err := oci.ResolveDigest(cmd.Context(), target, ref)
-	if err != nil {
-		return fmt.Errorf("resolve digest: %w", err)
 	}
 	printManifest(cmd.OutOrStdout(), m, digest, "")
 	return nil
@@ -57,13 +59,14 @@ func inspectGit(cmd *cobra.Command, reference string) error {
 		return fmt.Errorf("expected git dependency from %q", reference)
 	}
 	backend := &gitbackend.Backend{}
-	m, err := backend.Inspect(cmd.Context(), gitDep)
-	if err != nil {
-		return fmt.Errorf("inspect git artifact: %w", err)
-	}
 	commit, err := backend.ResolveCommit(cmd.Context(), gitDep)
 	if err != nil {
 		return fmt.Errorf("resolve git commit: %w", err)
+	}
+	gitDep.Commit = commit
+	m, err := backend.Inspect(cmd.Context(), gitDep)
+	if err != nil {
+		return fmt.Errorf("inspect git artifact: %w", err)
 	}
 	printManifest(cmd.OutOrStdout(), m, "", commit)
 	return nil

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -20,7 +20,7 @@ func newInspectCmd() *cobra.Command {
 		Example: "  striatum inspect localhost:5000/skills/my-skill:1.0.0\n  striatum inspect git:https://github.com/example/skill.git@v1.0.0",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			reference := args[0]
+			reference := strings.TrimSpace(args[0])
 
 			if strings.HasPrefix(reference, "git:") {
 				return inspectGit(cmd, reference)
@@ -34,6 +34,9 @@ func inspectOCI(cmd *cobra.Command, reference string) error {
 	target, ref, digest, err := resolveTargetAndRef(reference)
 	if err != nil {
 		return fmt.Errorf("resolve reference: %w", err)
+	}
+	if digest != "" && !artifact.IsValidDigest(digest) {
+		return fmt.Errorf("invalid digest %q: must match sha256:<64 lowercase hex chars>", digest)
 	}
 	if digest == "" {
 		digest, err = oci.ResolveDigest(cmd.Context(), target, ref)

--- a/internal/cli/inspect.go
+++ b/internal/cli/inspect.go
@@ -2,9 +2,13 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
+	"github.com/hbelmiro/striatum/pkg/artifact"
 	"github.com/hbelmiro/striatum/pkg/oci"
+	"github.com/hbelmiro/striatum/pkg/registry"
+	gitbackend "github.com/hbelmiro/striatum/pkg/registry/git"
 	"github.com/spf13/cobra"
 )
 
@@ -12,34 +16,78 @@ func newInspectCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "inspect",
 		Short:   "Display manifest and metadata of a remote artifact",
-		Long:    "Fetches and prints the artifact manifest (name, version, dependencies) without downloading layers. Reference can be a registry or oci:/path:tag.",
-		Example: "  striatum inspect localhost:5000/skills/my-skill:1.0.0",
+		Long:    "Fetches and prints the artifact manifest (name, version, dependencies) without downloading layers. Reference can be a registry, oci:/path:tag, or git:URL@ref.",
+		Example: "  striatum inspect localhost:5000/skills/my-skill:1.0.0\n  striatum inspect git:https://github.com/example/skill.git@v1.0.0",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reference := args[0]
-			target, ref, _, err := resolveTargetAndRef(reference)
-			if err != nil {
-				return fmt.Errorf("resolve reference: %w", err)
+
+			if strings.HasPrefix(reference, "git:") {
+				return inspectGit(cmd, reference)
 			}
-			m, err := oci.Inspect(cmd.Context(), target, ref)
-			if err != nil {
-				return fmt.Errorf("inspect artifact manifest and metadata: %w", err)
-			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Name:         %s\n", m.Metadata.Name)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Version:      %s\n", m.Metadata.Version)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Kind:         %s\n", m.Kind)
-			if m.Metadata.Description != "" {
-				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Description:  %s\n", m.Metadata.Description)
-			}
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Entrypoint:   %s\n", m.Spec.Entrypoint)
-			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Files:        %s\n", strings.Join(m.Spec.Files, ", "))
-			if len(m.Dependencies) > 0 {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Dependencies:")
-				for _, d := range m.Dependencies {
-					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  - %s [%s]\n", d.CanonicalRef(), d.Source())
-				}
-			}
-			return nil
+			return inspectOCI(cmd, reference)
 		},
+	}
+}
+
+func inspectOCI(cmd *cobra.Command, reference string) error {
+	target, ref, _, err := resolveTargetAndRef(reference)
+	if err != nil {
+		return fmt.Errorf("resolve reference: %w", err)
+	}
+	m, err := oci.Inspect(cmd.Context(), target, ref)
+	if err != nil {
+		return fmt.Errorf("inspect artifact manifest and metadata: %w", err)
+	}
+	digest, err := oci.ResolveDigest(cmd.Context(), target, ref)
+	if err != nil {
+		return fmt.Errorf("resolve digest: %w", err)
+	}
+	printManifest(cmd.OutOrStdout(), m, digest, "")
+	return nil
+}
+
+func inspectGit(cmd *cobra.Command, reference string) error {
+	loc, err := registry.ParseReference(reference)
+	if err != nil {
+		return fmt.Errorf("parse git reference: %w", err)
+	}
+	gitDep, ok := loc.(*artifact.GitDependency)
+	if !ok {
+		return fmt.Errorf("expected git dependency from %q", reference)
+	}
+	backend := &gitbackend.Backend{}
+	m, err := backend.Inspect(cmd.Context(), gitDep)
+	if err != nil {
+		return fmt.Errorf("inspect git artifact: %w", err)
+	}
+	commit, err := backend.ResolveCommit(cmd.Context(), gitDep)
+	if err != nil {
+		return fmt.Errorf("resolve git commit: %w", err)
+	}
+	printManifest(cmd.OutOrStdout(), m, "", commit)
+	return nil
+}
+
+func printManifest(w io.Writer, m *artifact.Manifest, digest, commit string) {
+	_, _ = fmt.Fprintf(w, "Name:         %s\n", m.Metadata.Name)
+	_, _ = fmt.Fprintf(w, "Version:      %s\n", m.Metadata.Version)
+	_, _ = fmt.Fprintf(w, "Kind:         %s\n", m.Kind)
+	if digest != "" {
+		_, _ = fmt.Fprintf(w, "Digest:       %s\n", digest)
+	}
+	if commit != "" {
+		_, _ = fmt.Fprintf(w, "Commit:       %s\n", commit)
+	}
+	if m.Metadata.Description != "" {
+		_, _ = fmt.Fprintf(w, "Description:  %s\n", m.Metadata.Description)
+	}
+	_, _ = fmt.Fprintf(w, "Entrypoint:   %s\n", m.Spec.Entrypoint)
+	_, _ = fmt.Fprintf(w, "Files:        %s\n", strings.Join(m.Spec.Files, ", "))
+	if len(m.Dependencies) > 0 {
+		_, _ = fmt.Fprintln(w, "Dependencies:")
+		for _, d := range m.Dependencies {
+			_, _ = fmt.Fprintf(w, "  - %s [%s]\n", d.CanonicalRef(), d.Source())
+		}
 	}
 }

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -106,6 +108,197 @@ func TestInspect_InvalidRef_Errors(t *testing.T) {
 	root.SetArgs([]string{"inspect", "oci:./nonexistent-layout:tag"})
 	if err := root.Execute(); err == nil {
 		t.Error("inspect with bad layout: expected error")
+	}
+}
+
+func TestInspect_OCI_DisplaysDigest(t *testing.T) {
+	baseDir := t.TempDir()
+	layoutDir := t.TempDir()
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "digest-test", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "SKILL.md"), []byte("# x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := oci.Pack(context.Background(), manifest, baseDir, layoutDir); err != nil {
+		t.Fatal(err)
+	}
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"inspect", "oci:" + layoutDir + ":digest-test:1.0.0"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("inspect: %v", err)
+	}
+	got := out.String()
+	digestPattern := regexp.MustCompile(`Digest:\s+sha256:[0-9a-f]{64}`)
+	if !digestPattern.MatchString(got) {
+		t.Errorf("output should contain Digest: sha256:<64 hex chars>\n%s", got)
+	}
+	lines := strings.Split(got, "\n")
+	var kindIdx, digestIdx, entryIdx int
+	for i, l := range lines {
+		if strings.HasPrefix(l, "Kind:") {
+			kindIdx = i
+		}
+		if strings.HasPrefix(l, "Digest:") {
+			digestIdx = i
+		}
+		if strings.HasPrefix(l, "Entrypoint:") {
+			entryIdx = i
+		}
+	}
+	if digestIdx == 0 {
+		t.Fatalf("Digest line not found in output:\n%s", got)
+	}
+	if kindIdx >= digestIdx || digestIdx >= entryIdx {
+		t.Errorf("Digest should appear between Kind and Entrypoint; Kind=%d Digest=%d Entrypoint=%d\n%s",
+			kindIdx, digestIdx, entryIdx, got)
+	}
+	if strings.Contains(got, "Commit:") {
+		t.Errorf("OCI output should not contain Commit: line\n%s", got)
+	}
+}
+
+func setupLocalGitRepo(t *testing.T, subPath, tagName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	artifactDir := workDir
+	if subPath != "" {
+		artifactDir = filepath.Join(workDir, subPath)
+		if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	manifest := `{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Skill",
+  "metadata": {"name": "git-skill", "version": "1.0.0"},
+  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
+}`
+	if err := os.WriteFile(filepath.Join(artifactDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(artifactDir, "SKILL.md"), []byte("# Git Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	run(workDir, "git", "tag", tagName)
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	p := filepath.ToSlash(bareDir)
+	if len(p) > 0 && p[0] != '/' {
+		p = "/" + p
+	}
+	return "file://" + p
+}
+
+func TestInspect_Git_DisplaysCommit(t *testing.T) {
+	repoURL := setupLocalGitRepo(t, "", "v1.0.0")
+	ref := "git:" + repoURL + "@v1.0.0"
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"inspect", ref})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("inspect git: %v", err)
+	}
+	got := out.String()
+	commitPattern := regexp.MustCompile(`Commit:\s+[0-9a-f]{40}`)
+	if !commitPattern.MatchString(got) {
+		t.Errorf("output should contain Commit: <40 hex chars>\n%s", got)
+	}
+	if !strings.Contains(got, "Name:") || !strings.Contains(got, "git-skill") {
+		t.Errorf("output should contain artifact name\n%s", got)
+	}
+	lines := strings.Split(got, "\n")
+	var kindIdx, commitIdx, entryIdx int
+	for i, l := range lines {
+		if strings.HasPrefix(l, "Kind:") {
+			kindIdx = i
+		}
+		if strings.HasPrefix(l, "Commit:") {
+			commitIdx = i
+		}
+		if strings.HasPrefix(l, "Entrypoint:") {
+			entryIdx = i
+		}
+	}
+	if commitIdx == 0 {
+		t.Fatalf("Commit line not found in output:\n%s", got)
+	}
+	if kindIdx >= commitIdx || commitIdx >= entryIdx {
+		t.Errorf("Commit should appear between Kind and Entrypoint; Kind=%d Commit=%d Entrypoint=%d\n%s",
+			kindIdx, commitIdx, entryIdx, got)
+	}
+	if strings.Contains(got, "Digest:") {
+		t.Errorf("Git output should not contain Digest: line\n%s", got)
+	}
+}
+
+func TestInspect_Git_WithSubPath(t *testing.T) {
+	repoURL := setupLocalGitRepo(t, "sub/dir", "v2.0.0")
+	ref := "git:" + repoURL + "@v2.0.0#sub/dir"
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"inspect", ref})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("inspect git with subpath: %v", err)
+	}
+	got := out.String()
+	commitPattern := regexp.MustCompile(`Commit:\s+[0-9a-f]{40}`)
+	if !commitPattern.MatchString(got) {
+		t.Errorf("output should contain Commit: <40 hex chars>\n%s", got)
+	}
+	if !strings.Contains(got, "git-skill") {
+		t.Errorf("output should contain artifact name from subpath\n%s", got)
+	}
+}
+
+func TestInspect_Git_InvalidRef_Errors(t *testing.T) {
+	root := NewRootCommand()
+	root.SetArgs([]string{"inspect", "git:https://example.com/repo.git"})
+	if err := root.Execute(); err == nil {
+		t.Error("inspect with invalid git ref (missing @ref): expected error")
 	}
 }
 

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -147,7 +147,7 @@ func TestInspect_OCI_DisplaysDigest(t *testing.T) {
 		t.Errorf("output should contain Digest: sha256:<64 hex chars>\n%s", got)
 	}
 	lines := strings.Split(got, "\n")
-	var kindIdx, digestIdx, entryIdx int
+	kindIdx, digestIdx, entryIdx := -1, -1, -1
 	for i, l := range lines {
 		if strings.HasPrefix(l, "Kind:") {
 			kindIdx = i
@@ -159,8 +159,8 @@ func TestInspect_OCI_DisplaysDigest(t *testing.T) {
 			entryIdx = i
 		}
 	}
-	if digestIdx == 0 {
-		t.Fatalf("Digest line not found in output:\n%s", got)
+	if kindIdx < 0 || digestIdx < 0 || entryIdx < 0 {
+		t.Fatalf("expected Kind, Digest, and Entrypoint lines in output:\n%s", got)
 	}
 	if kindIdx >= digestIdx || digestIdx >= entryIdx {
 		t.Errorf("Digest should appear between Kind and Entrypoint; Kind=%d Digest=%d Entrypoint=%d\n%s",
@@ -191,7 +191,7 @@ func TestInspect_Git_DisplaysCommit(t *testing.T) {
 		t.Errorf("output should contain artifact name\n%s", got)
 	}
 	lines := strings.Split(got, "\n")
-	var kindIdx, commitIdx, entryIdx int
+	kindIdx, commitIdx, entryIdx := -1, -1, -1
 	for i, l := range lines {
 		if strings.HasPrefix(l, "Kind:") {
 			kindIdx = i
@@ -203,8 +203,8 @@ func TestInspect_Git_DisplaysCommit(t *testing.T) {
 			entryIdx = i
 		}
 	}
-	if commitIdx == 0 {
-		t.Fatalf("Commit line not found in output:\n%s", got)
+	if kindIdx < 0 || commitIdx < 0 || entryIdx < 0 {
+		t.Fatalf("expected Kind, Commit, and Entrypoint lines in output:\n%s", got)
 	}
 	if kindIdx >= commitIdx || commitIdx >= entryIdx {
 		t.Errorf("Commit should appear between Kind and Entrypoint; Kind=%d Commit=%d Entrypoint=%d\n%s",

--- a/internal/cli/inspect_test.go
+++ b/internal/cli/inspect_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -170,63 +169,6 @@ func TestInspect_OCI_DisplaysDigest(t *testing.T) {
 	if strings.Contains(got, "Commit:") {
 		t.Errorf("OCI output should not contain Commit: line\n%s", got)
 	}
-}
-
-func setupLocalGitRepo(t *testing.T, subPath, tagName string) string {
-	t.Helper()
-	dir := t.TempDir()
-	workDir := filepath.Join(dir, "work")
-	bareDir := filepath.Join(dir, "bare.git")
-
-	run := func(wd string, args ...string) {
-		t.Helper()
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = wd
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
-		)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("%v failed: %s\n%s", args, err, out)
-		}
-	}
-
-	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
-	run(dir, "git", "clone", bareDir, workDir)
-
-	artifactDir := workDir
-	if subPath != "" {
-		artifactDir = filepath.Join(workDir, subPath)
-		if err := os.MkdirAll(artifactDir, 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	manifest := `{
-  "apiVersion": "striatum.dev/v1alpha2",
-  "kind": "Skill",
-  "metadata": {"name": "git-skill", "version": "1.0.0"},
-  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
-}`
-	if err := os.WriteFile(filepath.Join(artifactDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(artifactDir, "SKILL.md"), []byte("# Git Skill"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	run(workDir, "git", "add", "-A")
-	run(workDir, "git", "commit", "-m", "init")
-	run(workDir, "git", "tag", tagName)
-	run(workDir, "git", "push", "origin", "HEAD", "--tags")
-
-	p := filepath.ToSlash(bareDir)
-	if len(p) > 0 && p[0] != '/' {
-		p = "/" + p
-	}
-	return "file://" + p
 }
 
 func TestInspect_Git_DisplaysCommit(t *testing.T) {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1595,51 +1595,7 @@ func TestPullToStagingDir_RejectsUnsafeArtifactNames(t *testing.T) {
 }
 
 func setupGitRepo(t *testing.T) string {
-	t.Helper()
-	dir := t.TempDir()
-	workDir := filepath.Join(dir, "work")
-	bareDir := filepath.Join(dir, "bare.git")
-
-	run := func(wd string, args ...string) {
-		t.Helper()
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = wd
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
-			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
-		)
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			t.Fatalf("%v failed: %s\n%s", args, err, out)
-		}
-	}
-
-	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
-	run(dir, "git", "clone", bareDir, workDir)
-
-	manifest := `{
-  "apiVersion": "striatum.dev/v1alpha2",
-  "kind": "Skill",
-  "metadata": {"name": "git-skill", "version": "1.0.0"},
-  "spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]}
-}`
-	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Git Skill"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	run(workDir, "git", "add", "-A")
-	run(workDir, "git", "commit", "-m", "init")
-	run(workDir, "git", "tag", "v1.0.0")
-	run(workDir, "git", "push", "origin", "HEAD", "--tags")
-
-	p := filepath.ToSlash(bareDir)
-	if len(p) > 0 && p[0] != '/' {
-		p = "/" + p
-	}
-	return "file://" + p
+	return setupLocalGitRepo(t, "", "v1.0.0")
 }
 
 func TestInstall_GitRef_HappyPath(t *testing.T) {


### PR DESCRIPTION
Resolves #61

### Description

This pull request introduces support for inspecting Git and OCI artifacts with improved validation and handling of references. Key changes include:

- **Git Artifact Support**: Added `git:<url>@<ref>` support for the `inspect` and `install` commands, handling explicit commit resolutions and unique staging directories.
- **OCI Digest Parsing**: Enhanced parsing of OCI references with optional digest handling, including validation and support for immutable digests.
- **Validation Improvements**: Introduced safety checks for artifact names and versions, preventing path traversal and unsafe metadata inclusion.
- **Refactoring and Tests**: Refactored inspection logic for better modularity and added comprehensive unit tests to cover edge cases, including ambiguous Git references, validation failures, and digest resolution.

### Checklist

- [ ] Include unit tests to validate the changes made.
- [ ] Update documentation to reflect the updates in artifact handling and validation.
- [ ] Refactor code for better modularity and maintainability.
- [ ] Ensure compatibility with existing tools and workflows.

### Additional Notes

- Updates were made to the `pull`, `inspect`, and `install` commands to support digest and commit resolution with improved error handling.
- Dependencies were updated with version bumps to address security and compatibility concerns.