### PR TITLE
Add helper for target validation and CLI integration

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -36,17 +36,15 @@ func newInstallCmd() *cobra.Command {
 				return fmt.Errorf("install requires a reference (e.g. host/repo/name:tag, oci:/path:tag, or local directory path)")
 			}
 			reference := args[0]
-			target = strings.TrimSpace(target)
-			if target == "" {
-				return fmt.Errorf("--target is required (cursor or claude)")
-			}
-			if target != "cursor" && target != "claude" {
-				return fmt.Errorf("--target must be cursor or claude, got %q", target)
+			var err error
+			target, err = validateTarget(target)
+			if err != nil {
+				return err
 			}
 			return runInstall(cmd, reference, target, strings.TrimSpace(projectPath), force)
 		},
 	}
-	cmd.Flags().StringVar(&target, "target", "", "Install target: cursor or claude (required)")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "Install target: cursor or claude (required)")
 	cmd.Flags().StringVar(&projectPath, "project", "", "Project path for project-level install (e.g. .)")
 	cmd.Flags().BoolVar(&force, "force", false, "Overwrite conflicting versions")
 	cmd.Flags().BoolVar(&reinstallAll, "reinstall-all", false, "Replay all entries from install DB")

--- a/internal/cli/pack.go
+++ b/internal/cli/pack.go
@@ -14,6 +14,7 @@ import (
 const defaultLayoutDir = "build"
 
 func newPackCmd() *cobra.Command {
+	var manifestFlag, outputFlag string
 	cmd := &cobra.Command{
 		Use:   "pack",
 		Short: "Bundle the artifact into a local OCI Image Layout directory (default <project>/build/; override with -o / --output)",
@@ -22,14 +23,6 @@ func newPackCmd() *cobra.Command {
 By default the layout is written to <project>/build/. Use -o / --output to set a different directory; paths are relative to the shell’s current working directory (same as striatum pull --output).`,
 		Example: "  striatum pack\n  striatum pack -f packages/my-skill\n  striatum pack -o ./dist\n  striatum pack -f packages/my-skill -o /tmp/my-layout",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifestFlag, err := cmd.Flags().GetString("manifest")
-			if err != nil {
-				return err
-			}
-			outputFlag, err := cmd.Flags().GetString("output")
-			if err != nil {
-				return err
-			}
 			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
@@ -57,7 +50,7 @@ By default the layout is written to <project>/build/. Use -o / --output to set a
 			return nil
 		},
 	}
-	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
-	cmd.Flags().StringP("output", "o", "", "OCI layout output directory (default: <project>/build/; relative paths use the current working directory)")
+	cmd.Flags().StringVarP(&manifestFlag, "manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringVarP(&outputFlag, "output", "o", "", "OCI layout output directory (default: <project>/build/; relative paths use the current working directory)")
 	return cmd
 }

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -9,6 +9,7 @@ import (
 )
 
 func newPushCmd() *cobra.Command {
+	var manifestFlag string
 	cmd := &cobra.Command{
 		Use:     "push",
 		Short:   "Push the artifact to an OCI registry",
@@ -17,10 +18,6 @@ func newPushCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			reference := args[0]
-			manifestFlag, err := cmd.Flags().GetString("manifest")
-			if err != nil {
-				return err
-			}
 			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
@@ -42,6 +39,6 @@ func newPushCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringVarP(&manifestFlag, "manifest", "f", "", manifestFlagUsage)
 	return cmd
 }

--- a/internal/cli/skill_list.go
+++ b/internal/cli/skill_list.go
@@ -26,7 +26,7 @@ func newSkillListCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&installed, "installed", false, "List installed skills instead of cache")
-	cmd.Flags().StringVar(&target, "target", "", "Filter installed list by target (cursor or claude); only with --installed")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "Filter installed list by target (cursor or claude); only with --installed")
 	cmd.Flags().StringVar(&projectPath, "project", "", "Filter installed list by project path; only with --installed")
 	return cmd
 }
@@ -40,8 +40,12 @@ func runSkillList(cmd *cobra.Command, installed bool, target string, projectPath
 	}
 	out := cmd.OutOrStdout()
 	if installed {
-		if target != "" && target != "cursor" && target != "claude" {
-			return fmt.Errorf("--target must be cursor or claude, got %q", target)
+		if target != "" {
+			var err error
+			target, err = validateTarget(target)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Normalize project path for filtering

--- a/internal/cli/target.go
+++ b/internal/cli/target.go
@@ -1,0 +1,17 @@
+package cli
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var validTargets = []string{"cursor", "claude"}
+
+func validateTarget(raw string) (string, error) {
+	t := strings.TrimSpace(raw)
+	if slices.Contains(validTargets, t) {
+		return t, nil
+	}
+	return "", fmt.Errorf("--target must be cursor or claude, got %q", t)
+}

--- a/internal/cli/target_test.go
+++ b/internal/cli/target_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{"cursor", "cursor", "cursor", ""},
+		{"claude", "claude", "claude", ""},
+		{"cursor with spaces", "  cursor  ", "cursor", ""},
+		{"claude with spaces", "  claude  ", "claude", ""},
+		{"invalid target", "vscode", "", "must be cursor or claude"},
+		{"empty string", "", "", "must be cursor or claude"},
+		{"whitespace only", "   ", "", "must be cursor or claude"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateTarget(tt.input)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tt.want {
+					t.Errorf("validateTarget(%q) = %q, want %q", tt.input, got, tt.want)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestInstall_ShortTargetFlag(t *testing.T) {
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "install", "-t", "invalid", "localhost:5000/skills/foo:1.0.0"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("install -t invalid: expected error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "must be cursor or claude") {
+		t.Errorf("error should mention valid targets: %v", err)
+	}
+}
+
+func TestUninstall_ShortTargetFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "uninstall", "-t", "invalid", "foo"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("uninstall -t invalid: expected error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "must be cursor or claude") {
+		t.Errorf("error should mention valid targets: %v", err)
+	}
+}
+
+func TestSkillList_ShortTargetFlag(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "list", "--installed", "-t", "invalid"})
+	err := root.Execute()
+	if err == nil {
+		t.Error("skill list -t invalid: expected error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "must be cursor or claude") {
+		t.Errorf("error should mention valid targets: %v", err)
+	}
+}

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -23,12 +23,10 @@ func newUninstallCmd() *cobra.Command {
 			if name != strings.TrimSpace(raw) {
 				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "Note: version in %q ignored; uninstalling %q regardless of version\n", strings.TrimSpace(raw), name)
 			}
-			target = strings.TrimSpace(target)
-			if target == "" {
-				return fmt.Errorf("--target is required (cursor or claude)")
-			}
-			if target != "cursor" && target != "claude" {
-				return fmt.Errorf("--target must be cursor or claude, got %q", target)
+			var err error
+			target, err = validateTarget(target)
+			if err != nil {
+				return err
 			}
 			normProject := ""
 			if projectPath != "" {
@@ -41,7 +39,8 @@ func newUninstallCmd() *cobra.Command {
 			return runUninstall(cmd, name, target, normProject)
 		},
 	}
-	cmd.Flags().StringVar(&target, "target", "", "Uninstall from target: cursor or claude (required)")
+	cmd.Flags().StringVarP(&target, "target", "t", "", "Uninstall from target: cursor or claude (required)")
+	_ = cmd.MarkFlagRequired("target")
 	cmd.Flags().StringVar(&projectPath, "project", "", "Project path (match project-level install)")
 	return cmd
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -10,16 +10,13 @@ import (
 
 func newValidateCmd() *cobra.Command {
 	var checkDeps bool
+	var manifestFlag string
 	cmd := &cobra.Command{
 		Use:     "validate",
 		Short:   "Validate the local artifact.json",
 		Long:    "Validates schema and that all spec.files exist (paths are relative to the manifest file's directory). Use --check-deps to verify dependencies resolve from their declared sources.",
 		Example: "  striatum validate\n  striatum validate -f path/to/artifact.json\n  striatum validate --check-deps",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			manifestFlag, err := cmd.Flags().GetString("manifest")
-			if err != nil {
-				return err
-			}
 			manifestPath, projectRoot, err := resolveManifestAndProjectRoot(manifestFlag)
 			if err != nil {
 				return err
@@ -57,6 +54,6 @@ func newValidateCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&checkDeps, "check-deps", false, "Verify all dependencies exist in their declared registries")
-	cmd.Flags().StringP("manifest", "f", "", manifestFlagUsage)
+	cmd.Flags().StringVarP(&manifestFlag, "manifest", "f", "", manifestFlagUsage)
 	return cmd
 }


### PR DESCRIPTION
Resolves #44

### Description

This pull request introduces a `validateTarget` helper to centralize target validation logic across CLI commands. Changes include:

- Implementing `validateTarget` for improved target validation.
- Updating CLI commands (`install`, `uninstall`, `skill list`) to use this helper.
- Adding tests to cover edge cases for validation.
- Refactoring `target` flag handling for better clarity and introducing a `-t` alias for `--target`.

Additionally, this ensures consistent validation and ergonomic improvements for CLI users.

### Checks

- [ ] Documentation updated (if applicable)
- [ ] Tests added for new functionality
- [ ] All existing tests pass