### PR TITLE
Add support for "Prompt" artifact kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For `validate`, `pack`, and `push`, use `-f` / `--manifest` with a path to `arti
 
 The flag treats a path as a manifest **file** only when its final component is named `artifact.json` (case-insensitive, e.g. `Artifact.json` on disk). Any other final component is treated as a **project directory** and `artifact.json` is appended—even if that name is missing—so typos get errors pointing at the expected manifest path.
 
-- `striatum init` — scaffold an `artifact.json` (requires `--name`, `--kind`, `--entrypoint`)
+- `striatum init` — scaffold an `artifact.json` (requires `--name`, `--kind` (Skill, Prompt), `--entrypoint`)
 - `striatum validate` — validate local artifact and optionally check dependencies
 - `striatum pack` — bundle artifact into a local OCI Image Layout at `<project>/build/` by default (the manifest’s project directory, not necessarily the shell’s cwd—see `-f` / `--manifest`); optional `-o` / `--output` sets another layout directory (paths relative to the shell’s cwd, like `pull --output`)
 - `striatum push <reference>` — push to an OCI registry
@@ -59,6 +59,7 @@ The flag treats a path as a manifest **file** only when its final component is n
 
 ```bash
 striatum init --name my-skill --kind Skill --entrypoint SKILL.md
+striatum init --name severity-rubric --kind Prompt --entrypoint severity-rubric.md
 striatum validate
 striatum validate -f packages/my-skill
 striatum validate --check-deps --registry localhost:5000/skills

--- a/demo/example-prompt/artifact.json
+++ b/demo/example-prompt/artifact.json
@@ -1,0 +1,12 @@
+{
+  "apiVersion": "striatum.dev/v1alpha2",
+  "kind": "Prompt",
+  "metadata": {
+    "name": "example-prompt",
+    "version": "1.0.0"
+  },
+  "spec": {
+    "entrypoint": "severity-rubric.md",
+    "files": ["severity-rubric.md"]
+  }
+}

--- a/demo/example-prompt/severity-rubric.md
+++ b/demo/example-prompt/severity-rubric.md
@@ -1,0 +1,10 @@
+# Severity Rubric
+
+Fictitious demo prompt artifact consumed as a dependency by skills.
+
+## Levels
+
+- **Critical**: breaks core functionality or causes data loss
+- **High**: significant impact on usability or correctness
+- **Medium**: noticeable issue with a workaround
+- **Low**: cosmetic or minor inconvenience

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,9 +1,9 @@
-# Tutorial: packaging and distributing AI skills with Striatum
+# Tutorial: packaging and distributing AI artifacts with Striatum
 
-This walkthrough takes you through the full Striatum lifecycle — from creating an artifact, to pushing it to a registry, pulling it with dependency resolution, and installing it as a Cursor skill. By the end you will have:
+This walkthrough takes you through the full Striatum lifecycle, from creating an artifact, to pushing it to a registry, pulling it with dependency resolution, and installing it as a Cursor skill. By the end you will have:
 
-- Packed and pushed artifacts to an OCI registry
-- Pulled a skill with transitive **OCI** and **Git** dependencies
+- Packed and pushed artifacts (skills and prompts) to an OCI registry
+- Pulled a skill with transitive **OCI** and **Git** dependencies, including a Prompt dependency
 - Installed and uninstalled a skill in Cursor
 
 ## Prerequisites
@@ -22,13 +22,14 @@ go build -o striatum ./cmd/striatum
 
 The `demo/` directory contains sample artifacts you can experiment with:
 
-| Artifact                                                                         | Dependencies                                              | Stored in      |
-|----------------------------------------------------------------------------------|-----------------------------------------------------------|----------------|
-| `example-skill`                                                                  | `example-helper-a` (OCI), `example-helper-b` (OCI)        | OCI registry   |
-| `example-helper-a`                                                               | none                                                      | OCI registry   |
-| `example-helper-b`                                                               | none                                                      | OCI registry   |
-| `example-skill-git`                                                              | `example-helper-a` (OCI), `striatum-demo-git-skill` (Git) | OCI registry   |
-| [`striatum-demo-git-skill`](https://github.com/hbelmiro/striatum-demo-git-skill) | none                                                      | Git repository |
+| Artifact                                                                         | Kind   | Dependencies                                                                   | Stored in      |
+|----------------------------------------------------------------------------------|--------|--------------------------------------------------------------------------------|----------------|
+| `example-skill`                                                                  | Skill  | `example-helper-a` (OCI), `example-helper-b` (OCI), `example-prompt` (OCI)     | OCI registry   |
+| `example-helper-a`                                                               | Skill  | none                                                                           | OCI registry   |
+| `example-helper-b`                                                               | Skill  | none                                                                           | OCI registry   |
+| `example-prompt`                                                                 | Prompt | none                                                                           | OCI registry   |
+| `example-skill-git`                                                              | Skill  | `example-helper-a` (OCI), `striatum-demo-git-skill` (Git)                      | OCI registry   |
+| [`striatum-demo-git-skill`](https://github.com/hbelmiro/striatum-demo-git-skill) | Skill  | none                                                                           | Git repository |
 
 > **Note:** The checked-in `artifact.json` files for `example-skill` and `example-skill-git` do not include dependencies. The demo script (`scripts/demo.sh`) generates the full manifests at runtime, injecting the correct registry host and dependency declarations.
 
@@ -67,13 +68,14 @@ Leaf artifacts have no dependencies. Pack bundles the files listed in `artifact.
 ```bash
 (cd demo/example-helper-a && ../../striatum pack && ../../striatum push localhost:5050/demo/example-helper-a:1.0.0)
 (cd demo/example-helper-b && ../../striatum pack && ../../striatum push localhost:5050/demo/example-helper-b:1.0.0)
+(cd demo/example-prompt && ../../striatum pack && ../../striatum push localhost:5050/demo/example-prompt:1.0.0)
 ```
 
-After this, both helpers are available in the registry at `localhost:5050/demo/example-helper-{a,b}:1.0.0`.
+After this, both helpers and the prompt are available in the registry. Note that `example-prompt` has `kind: Prompt` in its manifest. Prompts follow the same pack/push/pull lifecycle as skills but cannot be installed into IDE skill directories (they are consumed as dependencies).
 
 ## Step 3 — Pack and push a root artifact with OCI dependencies
 
-`example-skill` depends on both helpers. The demo script generates an `artifact.json` with the correct registry host at runtime, but you can create one yourself:
+`example-skill` depends on both helpers and the prompt. The demo script generates an `artifact.json` with the correct registry host at runtime, but you can create one yourself:
 
 ```json
 {
@@ -83,12 +85,13 @@ After this, both helpers are available in the registry at `localhost:5050/demo/e
   "spec": { "entrypoint": "SKILL.md", "files": ["SKILL.md"] },
   "dependencies": [
     { "source": "oci", "registry": "localhost:5050", "repository": "demo/example-helper-a", "tag": "1.0.0" },
-    { "source": "oci", "registry": "localhost:5050", "repository": "demo/example-helper-b", "tag": "1.0.0" }
+    { "source": "oci", "registry": "localhost:5050", "repository": "demo/example-helper-b", "tag": "1.0.0" },
+    { "source": "oci", "registry": "localhost:5050", "repository": "demo/example-prompt", "tag": "1.0.0" }
   ]
 }
 ```
 
-Each OCI dependency declares its `registry`, `repository`, and `tag`. Striatum resolves them transitively at pull time.
+Each OCI dependency declares its `registry`, `repository`, and `tag`. Striatum resolves them transitively at pull time. Dependencies can be any supported artifact kind: here `example-prompt` is a Prompt consumed by the skill.
 
 To record the exact version a dependency was resolved from, add an optional `digest` field (OCI) or `commit` field (Git). These fields are included in the canonical reference and persisted in the manifest, making it possible to tell whether two manifests point to the same content:
 
@@ -125,13 +128,14 @@ Save that file as `artifact.json` alongside `demo/example-skill/SKILL.md`, then:
 ./striatum pull localhost:5050/demo/example-skill:1.0.0 -o ./demo-out
 ```
 
-Striatum reads the root manifest, discovers the two OCI dependencies, fetches their manifests, and downloads everything into the output directory:
+Striatum reads the root manifest, discovers the three OCI dependencies, fetches their manifests, and downloads everything into the output directory:
 
 ```text
 demo-out/
   example-skill/        # root artifact
-  example-helper-a/     # OCI dependency
-  example-helper-b/     # OCI dependency
+  example-helper-a/     # OCI dependency (Skill)
+  example-helper-b/     # OCI dependency (Skill)
+  example-prompt/       # OCI dependency (Prompt)
 ```
 
 ## Step 5 — Install and uninstall a skill
@@ -197,5 +201,5 @@ demo-out-git/
 ```bash
 docker rm -f striatum-demo
 rm -rf demo-out demo-out-git
-rm -rf demo/example-helper-a/build demo/example-helper-b/build demo/example-skill/build demo/example-skill-git/build
+rm -rf demo/example-helper-a/build demo/example-helper-b/build demo/example-prompt/build demo/example-skill/build demo/example-skill-git/build
 ```

--- a/internal/cli/fetcher.go
+++ b/internal/cli/fetcher.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hbelmiro/striatum/pkg/resolver"
 )
 
-// loadCachedSkillManifest tries to load a Skill manifest from the Striatum cache for
+// loadCachedManifest tries to load a manifest from the Striatum cache for
 // the given name@version. Returns (manifest, nil) on cache hit, (nil, nil) on cache miss
 // or after removing a corrupt entry, or (nil, error) on unrecoverable failures.
-func loadCachedSkillManifest(name, version string) (*artifact.Manifest, error) {
+func loadCachedManifest(name, version string) (*artifact.Manifest, error) {
 	cacheDir := installer.CacheDir(name, version)
 	manifestPath := filepath.Join(cacheDir, "artifact.json")
 	if _, err := os.Stat(manifestPath); err != nil {
@@ -33,7 +33,7 @@ func loadCachedSkillManifest(name, version string) (*artifact.Manifest, error) {
 		}
 		return nil, nil
 	}
-	if m.Metadata.Name != name || m.Metadata.Version != version || m.Kind != "Skill" {
+	if m.Metadata.Name != name || m.Metadata.Version != version || !artifact.IsSupportedKind(m.Kind) {
 		if removeErr := os.Remove(manifestPath); removeErr != nil {
 			return nil, fmt.Errorf("cache corruption for %s@%s; remove failed: %w", name, version, removeErr)
 		}
@@ -57,7 +57,7 @@ func (f *cacheFirstFetcher) FetchManifest(ctx context.Context, dep artifact.Depe
 	if !ok {
 		return f.next.FetchManifest(ctx, dep)
 	}
-	m, err := loadCachedSkillManifest(name, version)
+	m, err := loadCachedManifest(name, version)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/fetcher_test.go
+++ b/internal/cli/fetcher_test.go
@@ -207,9 +207,9 @@ func TestRemoteFetcher_UnsupportedDep(t *testing.T) {
 	}
 }
 
-// --- loadCachedSkillManifest edge cases ---
+// --- loadCachedManifest edge cases ---
 
-func TestLoadCachedSkillManifest_CorruptJSON_Recovers(t *testing.T) {
+func TestLoadCachedManifest_CorruptJSON_Recovers(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STRIATUM_HOME", home)
 
@@ -221,7 +221,7 @@ func TestLoadCachedSkillManifest_CorruptJSON_Recovers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m, err := loadCachedSkillManifest("corrupt", "1.0.0")
+	m, err := loadCachedManifest("corrupt", "1.0.0")
 	if err != nil {
 		t.Fatalf("should recover from corrupt cache, got err = %v", err)
 	}
@@ -230,7 +230,7 @@ func TestLoadCachedSkillManifest_CorruptJSON_Recovers(t *testing.T) {
 	}
 }
 
-func TestLoadCachedSkillManifest_WrongName_Recovers(t *testing.T) {
+func TestLoadCachedManifest_WrongName_Recovers(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STRIATUM_HOME", home)
 
@@ -249,7 +249,7 @@ func TestLoadCachedSkillManifest_WrongName_Recovers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := loadCachedSkillManifest("wrong-name", "1.0.0")
+	got, err := loadCachedManifest("wrong-name", "1.0.0")
 	if err != nil {
 		t.Fatalf("should recover from mismatched name, got err = %v", err)
 	}
@@ -258,7 +258,29 @@ func TestLoadCachedSkillManifest_WrongName_Recovers(t *testing.T) {
 	}
 }
 
-func TestLoadCachedSkillManifest_WrongKind_Recovers(t *testing.T) {
+func TestLoadCachedManifest_UnsupportedKind_Recovers(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+
+	cacheDir := installer.CacheDir("my-thing", "1.0.0")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data := []byte(`{"apiVersion":"striatum.dev/v1alpha2","kind":"Unknown","metadata":{"name":"my-thing","version":"1.0.0"},"spec":{"entrypoint":"THING.md","files":["THING.md"]}}`)
+	if err := os.WriteFile(filepath.Join(cacheDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadCachedManifest("my-thing", "1.0.0")
+	if err != nil {
+		t.Fatalf("should recover from unsupported kind, got err = %v", err)
+	}
+	if got != nil {
+		t.Error("should return nil manifest for unsupported kind")
+	}
+}
+
+func TestLoadCachedManifest_PromptKind_CacheHit(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("STRIATUM_HOME", home)
 
@@ -266,17 +288,26 @@ func TestLoadCachedSkillManifest_WrongKind_Recovers(t *testing.T) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	data := []byte(`{"apiVersion":"striatum.dev/v1alpha2","kind":"Prompt","metadata":{"name":"my-prompt","version":"1.0.0"},"spec":{"entrypoint":"PROMPT.md","files":["PROMPT.md"]}}`)
+	m := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   artifact.Metadata{Name: "my-prompt", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "severity-rubric.md", Files: []string{"severity-rubric.md"}},
+	}
+	data, _ := json.Marshal(m)
 	if err := os.WriteFile(filepath.Join(cacheDir, "artifact.json"), data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	got, err := loadCachedSkillManifest("my-prompt", "1.0.0")
+	got, err := loadCachedManifest("my-prompt", "1.0.0")
 	if err != nil {
-		t.Fatalf("should recover from wrong kind, got err = %v", err)
+		t.Fatalf("err = %v", err)
 	}
-	if got != nil {
-		t.Error("should return nil manifest for Kind != Skill")
+	if got == nil {
+		t.Fatal("should return manifest for Prompt kind cache hit")
+	}
+	if got.Kind != "Prompt" {
+		t.Errorf("kind = %q, want Prompt", got.Kind)
 	}
 }
 

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,7 +17,7 @@ func newInitCmd() *cobra.Command {
 		Use:     "init",
 		Short:   "Scaffold an artifact.json in the current directory",
 		Long:    "Creates an artifact.json in the current directory with the given name, version, and kind. Requires --name, --kind, and --entrypoint.",
-		Example: "  striatum init --name my-skill --kind Skill --entrypoint SKILL.md",
+		Example: "  striatum init --name my-skill --kind Skill --entrypoint SKILL.md\n  striatum init --name severity-rubric --kind Prompt --entrypoint severity-rubric.md",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name = strings.TrimSpace(name)
 			kind = strings.TrimSpace(kind)
@@ -65,7 +65,7 @@ func newInitCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Artifact name (required)")
 	cmd.Flags().StringVar(&version, "version", "0.1.0", "Artifact version")
-	cmd.Flags().StringVar(&kind, "kind", "", "Artifact kind (required, e.g. Skill)")
+	cmd.Flags().StringVar(&kind, "kind", "", "Artifact kind (required, e.g. Skill, Prompt)")
 	cmd.Flags().StringVar(&entrypoint, "entrypoint", "", "Entrypoint file (required)")
 	_ = cmd.MarkFlagRequired("name")
 	_ = cmd.MarkFlagRequired("kind")

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -98,6 +98,31 @@ func TestInit_RequiresEntrypoint(t *testing.T) {
 	}
 }
 
+func TestInit_PromptKind(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"init", "--name", "severity-rubric", "--kind", "Prompt", "--entrypoint", "severity-rubric.md"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("init --kind Prompt: %v", err)
+	}
+
+	m, err := artifact.Load(filepath.Join(dir, "artifact.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Kind != "Prompt" {
+		t.Errorf("kind = %q, want Prompt", m.Kind)
+	}
+	if m.Metadata.Name != "severity-rubric" {
+		t.Errorf("name = %q, want severity-rubric", m.Metadata.Name)
+	}
+	if err := artifact.Validate(m); err != nil {
+		t.Errorf("Validate: %v", err)
+	}
+}
+
 func TestInit_RejectsUnsupportedKind(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -195,7 +195,7 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 	var rootManifest *artifact.Manifest
 
 	if name, version, ok := refToCacheCandidate(reference); ok {
-		m, err := loadCachedSkillManifest(name, version)
+		m, err := loadCachedManifest(name, version)
 		if err != nil {
 			return err
 		}
@@ -278,6 +278,10 @@ func runInstall(cmd *cobra.Command, reference, target, projectPath string, force
 		}
 	}
 
+	if rootManifest.Kind == "Prompt" {
+		return fmt.Errorf("prompt artifacts cannot be installed; they are consumed as dependencies")
+	}
+
 	var resolved []resolver.ResolvedArtifact
 	if len(rootManifest.Dependencies) == 0 {
 		resolved = []resolver.ResolvedArtifact{{
@@ -324,6 +328,9 @@ func runLocalInstall(cmd *cobra.Command, reference, target, projectPath string, 
 	}
 	if err := artifact.ValidateLocal(rootManifest, absPath); err != nil {
 		return fmt.Errorf("validate local files: %w", err)
+	}
+	if rootManifest.Kind == "Prompt" {
+		return fmt.Errorf("prompt artifacts cannot be installed; they are consumed as dependencies")
 	}
 
 	name := rootManifest.Metadata.Name

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -487,19 +487,19 @@ func installResolvedArtifacts(cmd *cobra.Command, resolved []resolver.ResolvedAr
 	if existing == nil {
 		existing = []installer.InstalledEntry{}
 	}
-	required := buildRequired(existing, normProject)
-	for _, r := range resolved {
-		if v, ok := required[r.Name]; ok && v != r.Version && !force {
-			return fmt.Errorf("%s@%s conflicts with installed %s@%s (use --force to override)", r.Name, r.Version, r.Name, v)
-		}
-	}
-
 	installable := make([]resolver.ResolvedArtifact, 0, len(resolved))
 	for _, r := range resolved {
 		if r.Manifest != nil && r.Manifest.Kind == "Prompt" {
 			continue
 		}
 		installable = append(installable, r)
+	}
+
+	required := buildRequired(existing, normProject)
+	for _, r := range installable {
+		if v, ok := required[r.Name]; ok && v != r.Version && !force {
+			return fmt.Errorf("%s@%s conflicts with installed %s@%s (use --force to override)", r.Name, r.Version, r.Name, v)
+		}
 	}
 
 	targetDir, err := installer.Targets(target, projectPath)

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -494,11 +494,19 @@ func installResolvedArtifacts(cmd *cobra.Command, resolved []resolver.ResolvedAr
 		}
 	}
 
+	installable := make([]resolver.ResolvedArtifact, 0, len(resolved))
+	for _, r := range resolved {
+		if r.Manifest != nil && r.Manifest.Kind == "Prompt" {
+			continue
+		}
+		installable = append(installable, r)
+	}
+
 	targetDir, err := installer.Targets(target, projectPath)
 	if err != nil {
 		return fmt.Errorf("resolve target dir: %w", err)
 	}
-	for _, r := range resolved {
+	for _, r := range installable {
 		cd := installer.CacheDir(r.Name, r.Version)
 		if err := installer.InstallToTarget(cd, targetDir, r.Name); err != nil {
 			return fmt.Errorf("install %s to target: %w", r.Name, err)
@@ -513,7 +521,7 @@ func installResolvedArtifacts(cmd *cobra.Command, resolved []resolver.ResolvedAr
 		key := e.Skill + "|" + e.Target + "|" + e.ProjectPath
 		byKey[key] = e
 	}
-	for _, r := range resolved {
+	for _, r := range installable {
 		installedWith := rootName
 		if r.Name == rootName && r.Version == rootManifest.Metadata.Version {
 			installedWith = ""
@@ -554,7 +562,7 @@ func installResolvedArtifacts(cmd *cobra.Command, resolved []resolver.ResolvedAr
 	if err := installer.SaveInstalled(newEntries); err != nil {
 		return fmt.Errorf("save installed: %w", err)
 	}
-	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Installed", len(resolved), "artifact(s) to", targetDir)
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), "Installed", len(installable), "artifact(s) to", targetDir)
 	return nil
 }
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1536,8 +1536,8 @@ func TestInstall_LocalDir_SkillWithPromptDep(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("install skill with prompt dep: %v", err)
 	}
-	if !strings.Contains(out.String(), "Installed 2") {
-		t.Errorf("expected 2 artifacts installed, got %q", out.String())
+	if !strings.Contains(out.String(), "Installed 1") {
+		t.Errorf("expected 1 artifact installed (Prompt dep excluded), got %q", out.String())
 	}
 
 	rootTarget := filepath.Join(home, ".cursor", "skills", "skill-with-prompt")
@@ -1545,8 +1545,8 @@ func TestInstall_LocalDir_SkillWithPromptDep(t *testing.T) {
 		t.Errorf("root SKILL.md not installed: %v", err)
 	}
 	depTarget := filepath.Join(home, ".cursor", "skills", depName)
-	if _, err := os.Stat(filepath.Join(depTarget, "severity-rubric.md")); err != nil {
-		t.Errorf("prompt dep severity-rubric.md not installed to target: %v", err)
+	if _, err := os.Stat(depTarget); err == nil {
+		t.Errorf("prompt dep should NOT be installed to target dir, but %s exists", depTarget)
 	}
 }
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -821,6 +821,78 @@ func TestInstall_LocalDir_DotReference(t *testing.T) {
 	}
 }
 
+func TestInstall_LocalDir_RejectsPromptKind(t *testing.T) {
+	promptDir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+
+	m := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   artifact.Metadata{Name: "severity-rubric", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "severity-rubric.md", Files: []string{"severity-rubric.md"}},
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "artifact.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "severity-rubric.md"), []byte("# Severity Rubric"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", promptDir})
+	err = root.Execute()
+	if err == nil {
+		t.Fatal("expected error when installing a Prompt artifact")
+	}
+	if !strings.Contains(err.Error(), "prompt") || !strings.Contains(err.Error(), "cannot be installed") {
+		t.Errorf("error should explain Prompt cannot be installed, got: %v", err)
+	}
+}
+
+func TestInstall_OCI_RejectsPromptKind(t *testing.T) {
+	baseDir := t.TempDir()
+	layoutDir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+
+	manifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   artifact.Metadata{Name: "oci-prompt", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "rubric.md", Files: []string{"rubric.md"}},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "artifact.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "rubric.md"), []byte("# Rubric"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := oci.Pack(context.Background(), manifest, baseDir, layoutDir); err != nil {
+		t.Fatal(err)
+	}
+
+	root := NewRootCommand()
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", "oci:" + layoutDir + ":oci-prompt:1.0.0"})
+	err = root.Execute()
+	if err == nil {
+		t.Fatal("expected error when installing a Prompt artifact via OCI")
+	}
+	if !strings.Contains(err.Error(), "prompt") || !strings.Contains(err.Error(), "cannot be installed") {
+		t.Errorf("error should explain Prompt cannot be installed, got: %v", err)
+	}
+}
+
 func TestInstall_LocalDir_InvalidManifest(t *testing.T) {
 	skillDir := t.TempDir()
 	home := t.TempDir()
@@ -1376,6 +1448,105 @@ func TestInstall_LocalDir_WithDeps(t *testing.T) {
 	}
 	if len(entries) != 2 {
 		t.Fatalf("expected 2 DB entries, got %d", len(entries))
+	}
+}
+
+func TestInstall_LocalDir_SkillWithPromptDep(t *testing.T) {
+	home := t.TempDir()
+	skillDir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+
+	const depDigest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	depName := "severity-rubric"
+	depVersion := "1.0.0"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Header().Set("Content-Length", "512")
+			w.Header().Set("Docker-Content-Digest", depDigest)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	srvHost := strings.TrimPrefix(srv.URL, "http://")
+
+	dockerDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(`{"auths":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	rootManifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "skill-with-prompt", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+		Dependencies: []artifact.Dependency{
+			&artifact.OCIDependency{
+				RegistryHost: srvHost,
+				Repository:   depName,
+				Tag:          depVersion,
+			},
+		},
+	}
+	data, err := json.Marshal(rootManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "artifact.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# Skill with Prompt dep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	depCacheDir := installer.CacheDir(depName, depVersion)
+	if err := os.MkdirAll(depCacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	depManifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   artifact.Metadata{Name: depName, Version: depVersion},
+		Spec:       artifact.Spec{Entrypoint: "severity-rubric.md", Files: []string{"severity-rubric.md"}},
+	}
+	depData, err := json.Marshal(depManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depCacheDir, "artifact.json"), depData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depCacheDir, "severity-rubric.md"), []byte("# Severity Rubric"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := installer.WriteDigest(depCacheDir, depDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", skillDir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("install skill with prompt dep: %v", err)
+	}
+	if !strings.Contains(out.String(), "Installed 2") {
+		t.Errorf("expected 2 artifacts installed, got %q", out.String())
+	}
+
+	rootTarget := filepath.Join(home, ".cursor", "skills", "skill-with-prompt")
+	if _, err := os.Stat(filepath.Join(rootTarget, "SKILL.md")); err != nil {
+		t.Errorf("root SKILL.md not installed: %v", err)
+	}
+	depTarget := filepath.Join(home, ".cursor", "skills", depName)
+	if _, err := os.Stat(filepath.Join(depTarget, "severity-rubric.md")); err != nil {
+		t.Errorf("prompt dep severity-rubric.md not installed to target: %v", err)
 	}
 }
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -1550,6 +1550,102 @@ func TestInstall_LocalDir_SkillWithPromptDep(t *testing.T) {
 	}
 }
 
+func TestInstall_LocalDir_PromptDepSkipsConflictCheck(t *testing.T) {
+	home := t.TempDir()
+	skillDir := t.TempDir()
+	t.Setenv("STRIATUM_HOME", home)
+	t.Setenv("HOME", home)
+
+	const depDigest = "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+
+	depName := "shared-name"
+	depVersion := "2.0.0"
+
+	if err := installer.SaveInstalled([]installer.InstalledEntry{{
+		Skill:   depName,
+		Version: "1.0.0",
+		Target:  "cursor",
+		Status:  "ok",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && strings.Contains(r.URL.Path, "/manifests/") {
+			w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+			w.Header().Set("Content-Length", "512")
+			w.Header().Set("Docker-Content-Digest", depDigest)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	srvHost := strings.TrimPrefix(srv.URL, "http://")
+
+	dockerDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dockerDir, "config.json"), []byte(`{"auths":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	rootManifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   artifact.Metadata{Name: "my-skill", Version: "1.0.0"},
+		Spec:       artifact.Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+		Dependencies: []artifact.Dependency{
+			&artifact.OCIDependency{
+				RegistryHost: srvHost,
+				Repository:   depName,
+				Tag:          depVersion,
+			},
+		},
+	}
+	data, err := json.Marshal(rootManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "artifact.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("# My Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	depCacheDir := installer.CacheDir(depName, depVersion)
+	if err := os.MkdirAll(depCacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	depManifest := &artifact.Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   artifact.Metadata{Name: depName, Version: depVersion},
+		Spec:       artifact.Spec{Entrypoint: "prompt.md", Files: []string{"prompt.md"}},
+	}
+	depData, err := json.Marshal(depManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depCacheDir, "artifact.json"), depData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(depCacheDir, "prompt.md"), []byte("# Prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := installer.WriteDigest(depCacheDir, depDigest); err != nil {
+		t.Fatal(err)
+	}
+
+	out := &strings.Builder{}
+	root := NewRootCommand()
+	root.SetOut(out)
+	root.SetArgs([]string{"skill", "install", "--target", "cursor", skillDir})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("prompt dep should not trigger conflict check, got: %v", err)
+	}
+}
+
 func TestPullToStagingDir_CreatesIsolatedDir(t *testing.T) {
 	parentDir := t.TempDir()
 

--- a/pkg/artifact/manifest.go
+++ b/pkg/artifact/manifest.go
@@ -25,7 +25,8 @@ func IsValidCommitSHA(s string) bool { return commitPattern.MatchString(s) }
 const supportedAPIVersion = "striatum.dev/v1alpha2"
 
 var supportedKinds = map[string]bool{
-	"Skill": true,
+	"Prompt": true,
+	"Skill":  true,
 }
 
 // IsSupportedKind reports whether kind is a recognized artifact kind.

--- a/pkg/artifact/manifest_test.go
+++ b/pkg/artifact/manifest_test.go
@@ -513,6 +513,31 @@ func TestValidate_ValidManifest(t *testing.T) {
 	}
 }
 
+func TestValidate_PromptKind(t *testing.T) {
+	m := &Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Prompt",
+		Metadata:   Metadata{Name: "severity-rubric", Version: "1.0.0"},
+		Spec:       Spec{Entrypoint: "severity-rubric.md", Files: []string{"severity-rubric.md"}},
+	}
+	if err := Validate(m); err != nil {
+		t.Errorf("Validate() err = %v, want nil for Prompt kind", err)
+	}
+}
+
+func TestSupportedKindsList_IncludesPrompt(t *testing.T) {
+	list := SupportedKindsList()
+	if !strings.Contains(list, "Prompt") {
+		t.Errorf("SupportedKindsList() = %q, want it to contain Prompt", list)
+	}
+	if !strings.Contains(list, "Skill") {
+		t.Errorf("SupportedKindsList() = %q, want it to contain Skill", list)
+	}
+	if list != "Prompt, Skill" {
+		t.Errorf("SupportedKindsList() = %q, want alphabetical: Prompt, Skill", list)
+	}
+}
+
 func TestValidate_ValidManifestWithDeps(t *testing.T) {
 	m := &Manifest{
 		APIVersion: "striatum.dev/v1alpha2",

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -53,7 +53,7 @@ cd "$REPO_ROOT"
 # ---------------------------------------------------------------------------
 # 1) OCI artifacts: pack and push helpers first, then root
 # ---------------------------------------------------------------------------
-for dir in example-helper-a example-helper-b; do
+for dir in example-helper-a example-helper-b example-prompt; do
   echo "Packing and pushing $dir..."
   (cd "$DEMO_DIR/$dir" && "$STRIATUM" pack && "$STRIATUM" push "$REGISTRY_BASE/$dir:1.0.0")
 done
@@ -70,7 +70,8 @@ cat > "$SKILL_DIR/artifact.json" <<EOF
   "spec": { "entrypoint": "SKILL.md", "files": ["SKILL.md"] },
   "dependencies": [
     { "source": "oci", "registry": "$REGISTRY_HOST", "repository": "demo/example-helper-a", "tag": "1.0.0" },
-    { "source": "oci", "registry": "$REGISTRY_HOST", "repository": "demo/example-helper-b", "tag": "1.0.0" }
+    { "source": "oci", "registry": "$REGISTRY_HOST", "repository": "demo/example-helper-b", "tag": "1.0.0" },
+    { "source": "oci", "registry": "$REGISTRY_HOST", "repository": "demo/example-prompt", "tag": "1.0.0" }
   ]
 }
 EOF


### PR DESCRIPTION
Resolves #68

- Introduced "Prompt" artifact kind, consumed as dependencies only.
- Updated `init`, `install`, and `validate` commands with "Prompt" support.
- Prevent installation of "Prompt" artifacts into skill directories.
- Extended tests for new kind, including caching and dependency resolution.
- Enhanced documentation and examples to include "Prompt" usage scenarios.