### PR TITLE
chore(deps): bump github/codeql-action to 4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,17 +27,17 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
 
       # If Code scanning is not enabled (e.g. private repo without Advanced Security),
       # upload fails with "Resource not accessible". continue-on-error keeps the run green.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         continue-on-error: true
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Bump all `github/codeql-action` sub-actions (init, autobuild, analyze) to v4.36.3 (`54f647b7e1bb85c95cddabcd46b0c578ec92bc1a`) in a single PR to avoid version mismatch errors.

Dependabot bumps each sub-action individually, which causes CI failures because the actions must all use the same version. This PR supersedes the individual Dependabot PRs:

- #89 — Bump github/codeql-action/init from 4.36.2 to 4.36.3
- #90 — Bump github/codeql-action/analyze from 4.36.2 to 4.36.3
- #91 — Bump github/codeql-action/autobuild from 4.36.2 to 4.36.3

Once this PR is merged, those three PRs should be closed.