### PR TITLE
chore: group codeql-action dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"


### PR DESCRIPTION
## Summary
- Adds a Dependabot group for `codeql-action` under the `github-actions` ecosystem, so that updates to `github/codeql-action/*` are bundled into a single PR.

## Test plan
- [ ] Verify Dependabot picks up the new grouping on its next scheduled run