### PR TITLE
Support git dependencies without artifact.json in target repo

### DIFF
--- a/pkg/artifact/manifest.go
+++ b/pkg/artifact/manifest.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -22,7 +23,7 @@ func IsValidDigest(s string) bool { return digestPattern.MatchString(s) }
 // IsValidCommitSHA reports whether s is a valid full-length Git commit SHA (40 lowercase hex chars).
 func IsValidCommitSHA(s string) bool { return commitPattern.MatchString(s) }
 
-const supportedAPIVersion = "striatum.dev/v1alpha2"
+const SupportedAPIVersion = "striatum.dev/v1alpha2"
 
 var supportedKinds = map[string]bool{
 	"Prompt":   true,
@@ -115,10 +116,14 @@ func (d *OCIDependency) MarshalJSON() ([]byte, error) {
 
 // GitDependency is a dependency hosted in a Git repository.
 type GitDependency struct {
-	URL    string `json:"url"`
-	Ref    string `json:"ref"`
-	Path   string `json:"path,omitempty"`
-	Commit string `json:"commit,omitempty"`
+	URL        string   `json:"url"`
+	Ref        string   `json:"ref"`
+	Path       string   `json:"path,omitempty"`
+	Commit     string   `json:"commit,omitempty"`
+	Files      []string `json:"files,omitempty"`
+	Name       string   `json:"name,omitempty"`
+	Kind       string   `json:"kind,omitempty"`
+	Entrypoint string   `json:"entrypoint,omitempty"`
 }
 
 func (d *GitDependency) Source() string { return "git" }
@@ -144,22 +149,101 @@ func (d *GitDependency) Validate() error {
 	if d.Commit != "" && !IsValidCommitSHA(d.Commit) {
 		return fmt.Errorf("git dependency: commit must be a 40-character lowercase hex SHA, got %q", d.Commit)
 	}
+	if d.Files != nil {
+		if err := validateGitFiles(d.Files); err != nil {
+			return err
+		}
+	}
+	if d.Name != "" {
+		if err := validateGitName(d.Name); err != nil {
+			return err
+		}
+	}
+	if d.Kind != "" && !IsSupportedKind(d.Kind) {
+		return fmt.Errorf("git dependency: unsupported kind %q; supported: %s", d.Kind, supportedKindsList())
+	}
+	if err := validateGitEntrypoint(d.Entrypoint, d.Files); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateGitFiles(files []string) error {
+	if len(files) == 0 {
+		return errors.New("git dependency: files must not be an empty list (omit the field or provide entries)")
+	}
+	seen := make(map[string]bool, len(files))
+	for _, f := range files {
+		if f == "" {
+			return errors.New("git dependency: files must not contain empty strings")
+		}
+		if strings.Contains(f, "..") {
+			return fmt.Errorf("git dependency: files entry %q contains path traversal", f)
+		}
+		if filepath.IsAbs(f) {
+			return fmt.Errorf("git dependency: files entry %q is an absolute path", f)
+		}
+		if seen[f] {
+			return fmt.Errorf("git dependency: duplicate files entry %q", f)
+		}
+		seen[f] = true
+	}
+	return nil
+}
+
+func validateGitName(name string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("git dependency: name must not be whitespace-only")
+	}
+	if name != strings.TrimSpace(name) {
+		return errors.New("git dependency: name must not have leading or trailing whitespace")
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("git dependency: name %q must not contain slashes", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("git dependency: name %q is not allowed", name)
+	}
+	return nil
+}
+
+func validateGitEntrypoint(entrypoint string, files []string) error {
+	if entrypoint == "" {
+		return nil
+	}
+	if strings.Contains(entrypoint, "..") {
+		return fmt.Errorf("git dependency: entrypoint %q contains path traversal", entrypoint)
+	}
+	if filepath.IsAbs(entrypoint) {
+		return fmt.Errorf("git dependency: entrypoint %q is an absolute path", entrypoint)
+	}
+	if files != nil && !slices.Contains(files, entrypoint) {
+		return fmt.Errorf("git dependency: entrypoint %q must be listed in files", entrypoint)
+	}
 	return nil
 }
 
 func (d *GitDependency) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Source string `json:"source"`
-		URL    string `json:"url"`
-		Ref    string `json:"ref"`
-		Path   string `json:"path,omitempty"`
-		Commit string `json:"commit,omitempty"`
+		Source     string   `json:"source"`
+		URL       string   `json:"url"`
+		Ref       string   `json:"ref"`
+		Path      string   `json:"path,omitempty"`
+		Commit    string   `json:"commit,omitempty"`
+		Files     []string `json:"files,omitempty"`
+		Name      string   `json:"name,omitempty"`
+		Kind      string   `json:"kind,omitempty"`
+		Entrypoint string  `json:"entrypoint,omitempty"`
 	}{
-		Source: "git",
-		URL:    d.URL,
-		Ref:    d.Ref,
-		Path:   d.Path,
-		Commit: d.Commit,
+		Source:     "git",
+		URL:        d.URL,
+		Ref:        d.Ref,
+		Path:       d.Path,
+		Commit:     d.Commit,
+		Files:      d.Files,
+		Name:       d.Name,
+		Kind:       d.Kind,
+		Entrypoint: d.Entrypoint,
 	})
 }
 
@@ -284,8 +368,8 @@ func Validate(m *Manifest) error {
 	if m == nil {
 		return errors.New("manifest is nil")
 	}
-	if m.APIVersion != supportedAPIVersion {
-		return fmt.Errorf("unsupported apiVersion %q, want %s", m.APIVersion, supportedAPIVersion)
+	if m.APIVersion != SupportedAPIVersion {
+		return fmt.Errorf("unsupported apiVersion %q, want %s", m.APIVersion, SupportedAPIVersion)
 	}
 	if !supportedKinds[m.Kind] {
 		return fmt.Errorf("unsupported kind %q; supported: %s", m.Kind, supportedKindsList())

--- a/pkg/artifact/manifest_test.go
+++ b/pkg/artifact/manifest_test.go
@@ -1111,6 +1111,346 @@ func TestValidateLocal_StatError_NonNotExist(t *testing.T) {
 	}
 }
 
+// --- GitDependency new fields ---
+
+func TestGitDependency_Validate_FilesField(t *testing.T) {
+	base := func() *GitDependency {
+		return &GitDependency{URL: "https://example.com/r.git", Ref: "v1"}
+	}
+	tests := []struct {
+		name    string
+		dep     *GitDependency
+		wantErr string
+	}{
+		{"nil files", base(), ""},
+		{"valid files", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"SKILL.md"}}, ""},
+		{"multiple valid files", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"SKILL.md", "lib/helper.md"}}, ""},
+		{"empty slice", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{}}, "empty list"},
+		{"path traversal", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"../evil"}}, "path traversal"},
+		{"absolute path", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"/etc/passwd"}}, "absolute path"},
+		{"empty string entry", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"SKILL.md", ""}}, "empty"},
+		{"duplicate entries", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"SKILL.md", "SKILL.md"}}, "duplicate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() err = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitDependency_Validate_NameField(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     *GitDependency
+		wantErr string
+	}{
+		{"empty name", &GitDependency{URL: "https://example.com/r.git", Ref: "v1"}, ""},
+		{"clean name", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "my-skill"}, ""},
+		{"name with dot", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "my.skill"}, ""},
+		{"forward slash", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "a/b"}, "slashes"},
+		{"backslash", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "a\\b"}, "slashes"},
+		{"double dot", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: ".."}, "not allowed"},
+		{"single dot", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "."}, "not allowed"},
+		{"leading whitespace", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: " leading"}, "whitespace"},
+		{"trailing whitespace", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "trailing "}, "whitespace"},
+		{"whitespace only", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Name: "   "}, "whitespace"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() err = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitDependency_Validate_KindField(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     *GitDependency
+		wantErr string
+	}{
+		{"empty kind", &GitDependency{URL: "https://example.com/r.git", Ref: "v1"}, ""},
+		{"valid Skill", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Kind: "Skill"}, ""},
+		{"valid Prompt", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Kind: "Prompt"}, ""},
+		{"valid Workflow", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Kind: "Workflow"}, ""},
+		{"invalid kind", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Kind: "Widget"}, "unsupported kind"},
+		{"wrong case", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Kind: "skill"}, "unsupported kind"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() err = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitDependency_Validate_EntrypointField(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     *GitDependency
+		wantErr string
+	}{
+		{"empty entrypoint", &GitDependency{URL: "https://example.com/r.git", Ref: "v1"}, ""},
+		{"clean entrypoint", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Entrypoint: "SKILL.md"}, ""},
+		{"subdir entrypoint", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Entrypoint: "lib/main.md"}, ""},
+		{"path traversal", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Entrypoint: "../evil.md"}, "path traversal"},
+		{"absolute path", &GitDependency{URL: "https://example.com/r.git", Ref: "v1", Entrypoint: "/etc/passwd"}, "absolute path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() err = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitDependency_Validate_EntrypointInFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		dep     *GitDependency
+		wantErr string
+	}{
+		{
+			"entrypoint in files",
+			&GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"SKILL.md", "lib.md"}, Entrypoint: "SKILL.md"},
+			"",
+		},
+		{
+			"entrypoint not in files",
+			&GitDependency{URL: "https://example.com/r.git", Ref: "v1", Files: []string{"other.md"}, Entrypoint: "SKILL.md"},
+			"entrypoint",
+		},
+		{
+			"entrypoint set files nil",
+			&GitDependency{URL: "https://example.com/r.git", Ref: "v1", Entrypoint: "SKILL.md"},
+			"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.dep.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() err = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() err = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGitDependency_CanonicalRef_IgnoresNewFields(t *testing.T) {
+	base := &GitDependency{
+		URL:    "https://example.com/r.git",
+		Ref:    "v1.0.0",
+		Path:   "sub",
+		Commit: "abcdef0123456789abcdef0123456789abcdef01",
+	}
+	withFields := &GitDependency{
+		URL:        "https://example.com/r.git",
+		Ref:        "v1.0.0",
+		Path:       "sub",
+		Commit:     "abcdef0123456789abcdef0123456789abcdef01",
+		Files:      []string{"SKILL.md"},
+		Name:       "custom-name",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	if base.CanonicalRef() != withFields.CanonicalRef() {
+		t.Errorf("CanonicalRef should ignore new fields:\n  base:       %q\n  withFields: %q", base.CanonicalRef(), withFields.CanonicalRef())
+	}
+}
+
+func TestGitDependency_MarshalJSON_IncludesNewFields(t *testing.T) {
+	d := &GitDependency{
+		URL:        "https://example.com/r.git",
+		Ref:        "v1",
+		Files:      []string{"SKILL.md"},
+		Name:       "my-skill",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("MarshalJSON() err = %v", err)
+	}
+	s := string(data)
+	if !strings.Contains(s, `"files"`) {
+		t.Errorf("marshaled JSON should contain files: %s", s)
+	}
+	if !strings.Contains(s, `"name"`) {
+		t.Errorf("marshaled JSON should contain name: %s", s)
+	}
+	if !strings.Contains(s, `"kind"`) {
+		t.Errorf("marshaled JSON should contain kind: %s", s)
+	}
+	if !strings.Contains(s, `"entrypoint"`) {
+		t.Errorf("marshaled JSON should contain entrypoint: %s", s)
+	}
+}
+
+func TestGitDependency_MarshalJSON_OmitsEmptyNewFields(t *testing.T) {
+	d := &GitDependency{
+		URL: "https://example.com/r.git",
+		Ref: "v1",
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("MarshalJSON() err = %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"files"`) {
+		t.Errorf("marshaled JSON should omit empty files: %s", s)
+	}
+	if strings.Contains(s, `"name"`) {
+		t.Errorf("marshaled JSON should omit empty name: %s", s)
+	}
+	if strings.Contains(s, `"kind"`) {
+		t.Errorf("marshaled JSON should omit empty kind: %s", s)
+	}
+	if strings.Contains(s, `"entrypoint"`) {
+		t.Errorf("marshaled JSON should omit empty entrypoint: %s", s)
+	}
+}
+
+func TestManifest_UnmarshalJSON_GitDep_WithNewFields(t *testing.T) {
+	data := `{
+		"apiVersion": "striatum.dev/v1alpha2",
+		"kind": "Skill",
+		"metadata": {"name": "x", "version": "1.0.0"},
+		"spec": {"entrypoint": "SKILL.md", "files": ["SKILL.md"]},
+		"dependencies": [
+			{
+				"source": "git",
+				"url": "https://example.com/r.git",
+				"ref": "main",
+				"path": "skills/review",
+				"commit": "abcdef0123456789abcdef0123456789abcdef01",
+				"files": ["SKILL.md", "lib.md"],
+				"name": "my-review",
+				"kind": "Skill",
+				"entrypoint": "SKILL.md"
+			}
+		]
+	}`
+	var m Manifest
+	if err := json.Unmarshal([]byte(data), &m); err != nil {
+		t.Fatalf("UnmarshalJSON() err = %v", err)
+	}
+	d, ok := m.Dependencies[0].(*GitDependency)
+	if !ok {
+		t.Fatalf("type = %T, want *GitDependency", m.Dependencies[0])
+	}
+	if len(d.Files) != 2 || d.Files[0] != "SKILL.md" || d.Files[1] != "lib.md" {
+		t.Errorf("Files = %v", d.Files)
+	}
+	if d.Name != "my-review" {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if d.Kind != "Skill" {
+		t.Errorf("Kind = %q", d.Kind)
+	}
+	if d.Entrypoint != "SKILL.md" {
+		t.Errorf("Entrypoint = %q", d.Entrypoint)
+	}
+}
+
+func TestManifest_Roundtrip_WithNewFields(t *testing.T) {
+	original := Manifest{
+		APIVersion: "striatum.dev/v1alpha2",
+		Kind:       "Skill",
+		Metadata:   Metadata{Name: "test", Version: "1.0.0"},
+		Spec:       Spec{Entrypoint: "SKILL.md", Files: []string{"SKILL.md"}},
+		Dependencies: []Dependency{
+			&GitDependency{
+				URL:        "https://example.com/r.git",
+				Ref:        "main",
+				Path:       "skills/review",
+				Commit:     "abcdef0123456789abcdef0123456789abcdef01",
+				Files:      []string{"SKILL.md", "lib.md"},
+				Name:       "review-skill",
+				Kind:       "Skill",
+				Entrypoint: "SKILL.md",
+			},
+		},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal err = %v", err)
+	}
+	var decoded Manifest
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal err = %v", err)
+	}
+	d, ok := decoded.Dependencies[0].(*GitDependency)
+	if !ok {
+		t.Fatalf("type = %T", decoded.Dependencies[0])
+	}
+	if len(d.Files) != 2 || d.Files[0] != "SKILL.md" || d.Files[1] != "lib.md" {
+		t.Errorf("Files = %v", d.Files)
+	}
+	if d.Name != "review-skill" {
+		t.Errorf("Name = %q", d.Name)
+	}
+	if d.Kind != "Skill" {
+		t.Errorf("Kind = %q", d.Kind)
+	}
+	if d.Entrypoint != "SKILL.md" {
+		t.Errorf("Entrypoint = %q", d.Entrypoint)
+	}
+}
+
 func TestValidateLocal_InvalidPath_Absolute(t *testing.T) {
 	dir := t.TempDir()
 	absPath := filepath.Join(dir, "SKILL.md")

--- a/pkg/registry/git/git.go
+++ b/pkg/registry/git/git.go
@@ -5,10 +5,12 @@ package git
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	gogit "github.com/go-git/go-git/v5"
@@ -30,7 +32,15 @@ func (b *Backend) Inspect(ctx context.Context, dep *artifact.GitDependency) (*ar
 	err := withTree(ctx, dep, func(tree *object.Tree) error {
 		var readErr error
 		m, readErr = readManifestFromTree(tree, dep.Path)
-		return readErr
+		if readErr == nil {
+			return nil
+		}
+		if !errors.Is(readErr, object.ErrFileNotFound) {
+			return readErr
+		}
+		var synthErr error
+		m, synthErr = synthesizeManifest(tree, dep)
+		return synthErr
 	})
 	return m, err
 }
@@ -133,8 +143,16 @@ func (b *Backend) ResolveCommit(ctx context.Context, dep *artifact.GitDependency
 func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputDir string) error {
 	return withTree(ctx, dep, func(tree *object.Tree) error {
 		m, err := readManifestFromTree(tree, dep.Path)
+		synthetic := false
 		if err != nil {
-			return err
+			if !errors.Is(err, object.ErrFileNotFound) {
+				return err
+			}
+			m, err = synthesizeManifest(tree, dep)
+			if err != nil {
+				return err
+			}
+			synthetic = true
 		}
 
 		if err := validateFilePaths(m.Spec.Files); err != nil {
@@ -161,6 +179,9 @@ func (b *Backend) Pull(ctx context.Context, dep *artifact.GitDependency, outputD
 			}
 		}
 
+		if synthetic {
+			return writeSyntheticManifest(m, filepath.Join(destDir, "artifact.json"))
+		}
 		manifestSrc := "artifact.json"
 		if base != "" {
 			manifestSrc = base + "/" + manifestSrc
@@ -235,6 +256,85 @@ func readManifestFromTree(tree *object.Tree, basePath string) (*artifact.Manifes
 		return nil, fmt.Errorf("parse artifact.json: %w", err)
 	}
 	return &m, nil
+}
+
+func synthesizeManifest(tree *object.Tree, dep *artifact.GitDependency) (*artifact.Manifest, error) {
+	if dep.Kind == "" {
+		return nil, fmt.Errorf("manifestless git dependency: kind is required when no artifact.json is present")
+	}
+	if dep.Entrypoint == "" {
+		return nil, fmt.Errorf("manifestless git dependency: entrypoint is required when no artifact.json is present")
+	}
+	if dep.Commit == "" {
+		return nil, fmt.Errorf("manifestless git dependency: commit is required when no artifact.json is present")
+	}
+	name := dep.Name
+	if name == "" {
+		if dep.Path != "" {
+			name = filepath.Base(dep.Path)
+		} else {
+			return nil, fmt.Errorf("manifestless git dependency: name is required when path is not set")
+		}
+	}
+
+	var files []string
+	if dep.Files != nil {
+		files = slices.Clone(dep.Files)
+	} else {
+		var err error
+		files, err = collectFilesFromTree(tree, dep.Path)
+		if err != nil {
+			return nil, err
+		}
+		if len(files) == 0 {
+			return nil, fmt.Errorf("no files found under path %q", dep.Path)
+		}
+	}
+
+	if !slices.Contains(files, dep.Entrypoint) {
+		return nil, fmt.Errorf("manifestless git dependency: entrypoint %q not found among files", dep.Entrypoint)
+	}
+
+	return &artifact.Manifest{
+		APIVersion: artifact.SupportedAPIVersion,
+		Kind:       dep.Kind,
+		Metadata: artifact.Metadata{
+			Name:    name,
+			Version: dep.Commit,
+		},
+		Spec: artifact.Spec{
+			Entrypoint: dep.Entrypoint,
+			Files:      files,
+		},
+	}, nil
+}
+
+func collectFilesFromTree(tree *object.Tree, basePath string) ([]string, error) {
+	subtree := tree
+	if basePath != "" {
+		var err error
+		subtree, err = tree.Tree(basePath)
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", basePath, err)
+		}
+	}
+	var files []string
+	err := subtree.Files().ForEach(func(f *object.File) error {
+		files = append(files, f.Name)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("enumerate files: %w", err)
+	}
+	return files, nil
+}
+
+func writeSyntheticManifest(m *artifact.Manifest, path string) error {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshal synthetic artifact.json: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
 }
 
 // validateFilePaths rejects paths that would escape the destination directory.

--- a/pkg/registry/git/git_manifestless_test.go
+++ b/pkg/registry/git/git_manifestless_test.go
@@ -1,0 +1,714 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hbelmiro/striatum/pkg/artifact"
+)
+
+// setupLocalRepoWithoutManifest creates a bare git repo with the given files
+// at subPath but NO artifact.json, tagged with tagName.
+// files maps relative path -> content.
+// Returns (file:// URL, commit SHA).
+func setupLocalRepoWithoutManifest(t *testing.T, subPath, tagName string, files map[string]string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	baseDir := workDir
+	if subPath != "" {
+		baseDir = filepath.Join(workDir, subPath)
+		if err := os.MkdirAll(baseDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for path, content := range files {
+		full := filepath.Join(baseDir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	sha := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "tag", tagName)
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	return fileURL(bareDir), sha
+}
+
+// manifestlessDep builds a GitDependency for a manifestless repo with required fields.
+func manifestlessDep(url, ref, path, commit string, files []string) *artifact.GitDependency {
+	return &artifact.GitDependency{
+		URL:        url,
+		Ref:        ref,
+		Path:       path,
+		Commit:     commit,
+		Files:      files,
+		Name:       "",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+}
+
+// --- Inspect: manifestless ---
+
+func TestBackend_Inspect_NoManifest_WithFiles(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/my-skill", "v1.0.0", map[string]string{
+		"SKILL.md": "# My Skill",
+		"lib.md":   "# Lib",
+	})
+	b := &Backend{}
+	dep := manifestlessDep(url, "v1.0.0", "skills/my-skill", sha, []string{"SKILL.md", "lib.md"})
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Name != "my-skill" {
+		t.Errorf("Name = %q, want %q", m.Metadata.Name, "my-skill")
+	}
+	if m.Metadata.Version != sha {
+		t.Errorf("Version = %q, want commit SHA %q", m.Metadata.Version, sha)
+	}
+	if m.Kind != "Skill" {
+		t.Errorf("Kind = %q, want %q", m.Kind, "Skill")
+	}
+	if m.Spec.Entrypoint != "SKILL.md" {
+		t.Errorf("Entrypoint = %q, want %q", m.Spec.Entrypoint, "SKILL.md")
+	}
+	if len(m.Spec.Files) != 2 {
+		t.Errorf("Files = %v, want 2 files", m.Spec.Files)
+	}
+	if m.APIVersion != artifact.SupportedAPIVersion {
+		t.Errorf("APIVersion = %q, want %q", m.APIVersion, artifact.SupportedAPIVersion)
+	}
+	if len(m.Dependencies) != 0 {
+		t.Errorf("Dependencies should be nil/empty, got %v", m.Dependencies)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_WithoutFiles_AllFilesUnderPath(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/review", "v1.0.0", map[string]string{
+		"SKILL.md":      "# Skill",
+		"lib/helper.md": "# Helper",
+		"lib/utils.md":  "# Utils",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/review",
+		Commit:     sha,
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if len(m.Spec.Files) != 3 {
+		t.Errorf("Files = %v, want 3 files (all under path)", m.Spec.Files)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_RootPath_AllFiles(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "", "v1.0.0", map[string]string{
+		"SKILL.md": "# Root Skill",
+		"extra.md": "# Extra",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Commit:     sha,
+		Name:       "root-skill",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Name != "root-skill" {
+		t.Errorf("Name = %q, want %q", m.Metadata.Name, "root-skill")
+	}
+	if len(m.Spec.Files) != 2 {
+		t.Errorf("Files = %v, want 2 files", m.Spec.Files)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_UsesDepName(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/review", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := manifestlessDep(url, "v1.0.0", "skills/review", sha, []string{"SKILL.md"})
+	dep.Name = "custom-name"
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Name != "custom-name" {
+		t.Errorf("Name = %q, want %q", m.Metadata.Name, "custom-name")
+	}
+}
+
+func TestBackend_Inspect_NoManifest_PathDoesNotExist_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "nonexistent/path",
+		Commit:     sha,
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail for nonexistent path")
+	}
+}
+
+func TestBackend_Inspect_NoManifest_NoKind_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/s",
+		Commit:     sha,
+		Files:      []string{"SKILL.md"},
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail when kind is missing for manifestless dep")
+	}
+	if !strings.Contains(err.Error(), "kind") {
+		t.Errorf("error should mention kind: %v", err)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_NoEntrypoint_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:    url,
+		Ref:    "v1.0.0",
+		Path:   "skills/s",
+		Commit: sha,
+		Files:  []string{"SKILL.md"},
+		Kind:   "Skill",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail when entrypoint is missing for manifestless dep")
+	}
+	if !strings.Contains(err.Error(), "entrypoint") {
+		t.Errorf("error should mention entrypoint: %v", err)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_NoCommit_Fails(t *testing.T) {
+	url, _ := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/s",
+		Files:      []string{"SKILL.md"},
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail when commit is missing for manifestless dep")
+	}
+	if !strings.Contains(err.Error(), "commit") {
+		t.Errorf("error should mention commit: %v", err)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_NoNameNoPath_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Commit:     sha,
+		Files:      []string{"SKILL.md"},
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail when neither name nor path is set for manifestless dep")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention name: %v", err)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_EntrypointNotInCollectedFiles_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"README.md": "# Readme",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/s",
+		Commit:     sha,
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should fail when entrypoint is not among collected files")
+	}
+	if !strings.Contains(err.Error(), "entrypoint") {
+		t.Errorf("error should mention entrypoint: %v", err)
+	}
+}
+
+func TestBackend_Inspect_HasManifest_IgnoresDepFields(t *testing.T) {
+	url := setupLocalRepo(t, "packages/skill", "v1.0.0")
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "packages/skill",
+		Files:      []string{"different.md"},
+		Name:       "override-name",
+		Kind:       "Prompt",
+		Entrypoint: "different.md",
+	}
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Name != "test-skill" {
+		t.Errorf("Name = %q, want %q (from artifact.json, not dep)", m.Metadata.Name, "test-skill")
+	}
+	if m.Kind != "Skill" {
+		t.Errorf("Kind = %q, want %q (from artifact.json)", m.Kind, "Skill")
+	}
+}
+
+func TestBackend_Inspect_MalformedManifest_WithFiles_StillErrors(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte("{invalid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	sha := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "tag", "v1.0.0")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        fileURL(bareDir),
+		Ref:        "v1.0.0",
+		Commit:     sha,
+		Files:      []string{"SKILL.md"},
+		Name:       "my-skill",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	_, err := b.Inspect(context.Background(), dep)
+	if err == nil {
+		t.Fatal("Inspect() should error for malformed artifact.json, NOT fall back to dep.Files")
+	}
+	if !strings.Contains(err.Error(), "parse artifact.json") {
+		t.Errorf("error should mention parse artifact.json: %v", err)
+	}
+}
+
+func TestBackend_Inspect_NoManifest_AtSubPath_ManifestAtRoot(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+
+	manifest := `{"apiVersion":"striatum.dev/v1alpha2","kind":"Skill","metadata":{"name":"root","version":"1.0.0"},"spec":{"entrypoint":"SKILL.md","files":["SKILL.md"]}}`
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Root"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	subDir := filepath.Join(workDir, "extras", "review")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "REVIEW.md"), []byte("# Review"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	sha := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "tag", "v1.0.0")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        fileURL(bareDir),
+		Ref:        "v1.0.0",
+		Path:       "extras/review",
+		Commit:     sha,
+		Files:      []string{"REVIEW.md"},
+		Kind:       "Skill",
+		Entrypoint: "REVIEW.md",
+	}
+	m, err := b.Inspect(context.Background(), dep)
+	if err != nil {
+		t.Fatalf("Inspect() err = %v", err)
+	}
+	if m.Metadata.Name != "review" {
+		t.Errorf("Name = %q, want %q (derived from path)", m.Metadata.Name, "review")
+	}
+}
+
+// --- Pull: manifestless ---
+
+func TestBackend_Pull_NoManifest_WithFiles(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/my-skill", "v1.0.0", map[string]string{
+		"SKILL.md": "# My Skill",
+		"lib.md":   "# Lib",
+	})
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := manifestlessDep(url, "v1.0.0", "skills/my-skill", sha, []string{"SKILL.md", "lib.md"})
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+
+	skillDir := filepath.Join(outDir, "my-skill")
+	data, err := os.ReadFile(filepath.Join(skillDir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(data), "My Skill") {
+		t.Errorf("SKILL.md content = %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "lib.md")); err != nil {
+		t.Errorf("lib.md missing: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_WithoutFiles_AllFiles(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/review", "v1.0.0", map[string]string{
+		"SKILL.md":        "# Skill",
+		"lib/helper.md":   "# Helper",
+		"lib/sub/deep.md": "# Deep",
+	})
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/review",
+		Commit:     sha,
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+
+	skillDir := filepath.Join(outDir, "review")
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "lib/helper.md")); err != nil {
+		t.Errorf("lib/helper.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "lib/sub/deep.md")); err != nil {
+		t.Errorf("lib/sub/deep.md missing: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_UsesDepName(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/review", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := manifestlessDep(url, "v1.0.0", "skills/review", sha, []string{"SKILL.md"})
+	dep.Name = "custom-name"
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "custom-name", "SKILL.md")); err != nil {
+		t.Errorf("expected output dir named custom-name: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_RejectsPathTraversal(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Path:       "skills/s",
+		Commit:     sha,
+		Files:      []string{"../../../etc/passwd"},
+		Kind:       "Skill",
+		Entrypoint: "../../../etc/passwd",
+	}
+	err := b.Pull(context.Background(), dep, t.TempDir())
+	if err == nil {
+		t.Fatal("Pull() should reject path traversal in dep.Files")
+	}
+	if !strings.Contains(err.Error(), "unsafe") {
+		t.Errorf("error should mention unsafe: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_MissingFile_Fails(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/s", "v1.0.0", map[string]string{
+		"SKILL.md": "# Skill",
+	})
+	b := &Backend{}
+	dep := manifestlessDep(url, "v1.0.0", "skills/s", sha, []string{"SKILL.md", "nonexistent.md"})
+	err := b.Pull(context.Background(), dep, t.TempDir())
+	if err == nil {
+		t.Fatal("Pull() should fail when dep.Files references a nonexistent file")
+	}
+	if !strings.Contains(err.Error(), "nonexistent.md") {
+		t.Errorf("error should mention the missing file: %v", err)
+	}
+}
+
+func TestBackend_Pull_HasManifest_IgnoresDepFiles(t *testing.T) {
+	url := setupLocalRepo(t, "", "v1.0.0")
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Files:      []string{"nonexistent.md"},
+		Name:       "override-name",
+		Kind:       "Prompt",
+		Entrypoint: "nonexistent.md",
+	}
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v (artifact.json should take precedence, ignoring dep.Files)", err)
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "test-skill", "SKILL.md")); err != nil {
+		t.Errorf("expected test-skill/SKILL.md from artifact.json: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_RootPath_AllFiles(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "", "v1.0.0", map[string]string{
+		"SKILL.md": "# Root Skill",
+		"extra.md": "# Extra",
+	})
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := &artifact.GitDependency{
+		URL:        url,
+		Ref:        "v1.0.0",
+		Commit:     sha,
+		Name:       "root-skill",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+	skillDir := filepath.Join(outDir, "root-skill")
+	if _, err := os.Stat(filepath.Join(skillDir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(skillDir, "extra.md")); err != nil {
+		t.Errorf("extra.md missing: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_MalformedManifest_WithFiles_StillErrors(t *testing.T) {
+	dir := t.TempDir()
+	workDir := filepath.Join(dir, "work")
+	bareDir := filepath.Join(dir, "bare.git")
+
+	run := func(wd string, args ...string) string {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = wd
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+			"GIT_CONFIG_NOSYSTEM=1", "GIT_CONFIG_GLOBAL="+os.DevNull,
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("%v failed: %s\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+
+	run(dir, "git", "init", "--bare", "-b", "master", bareDir)
+	run(dir, "git", "clone", bareDir, workDir)
+	if err := os.WriteFile(filepath.Join(workDir, "artifact.json"), []byte("{bad json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workDir, "SKILL.md"), []byte("# Skill"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(workDir, "git", "add", "-A")
+	run(workDir, "git", "commit", "-m", "init")
+	sha := run(workDir, "git", "rev-parse", "HEAD")
+	run(workDir, "git", "tag", "v1.0.0")
+	run(workDir, "git", "push", "origin", "HEAD", "--tags")
+
+	b := &Backend{}
+	dep := &artifact.GitDependency{
+		URL:        fileURL(bareDir),
+		Ref:        "v1.0.0",
+		Commit:     sha,
+		Files:      []string{"SKILL.md"},
+		Name:       "my-skill",
+		Kind:       "Skill",
+		Entrypoint: "SKILL.md",
+	}
+	err := b.Pull(context.Background(), dep, t.TempDir())
+	if err == nil {
+		t.Fatal("Pull() should error for malformed artifact.json, NOT fall back")
+	}
+	if !strings.Contains(err.Error(), "parse artifact.json") {
+		t.Errorf("error should mention parse artifact.json: %v", err)
+	}
+}
+
+func TestBackend_Pull_NoManifest_WritesSyntheticManifest(t *testing.T) {
+	url, sha := setupLocalRepoWithoutManifest(t, "skills/review", "v1.0.0", map[string]string{
+		"SKILL.md": "# Review Skill",
+	})
+	b := &Backend{}
+	outDir := t.TempDir()
+	dep := manifestlessDep(url, "v1.0.0", "skills/review", sha, []string{"SKILL.md"})
+	err := b.Pull(context.Background(), dep, outDir)
+	if err != nil {
+		t.Fatalf("Pull() err = %v", err)
+	}
+
+	syntheticPath := filepath.Join(outDir, "review", "artifact.json")
+	m, err := artifact.Load(syntheticPath)
+	if err != nil {
+		t.Fatalf("failed to load synthetic artifact.json: %v", err)
+	}
+	if m.APIVersion != artifact.SupportedAPIVersion {
+		t.Errorf("APIVersion = %q", m.APIVersion)
+	}
+	if m.Kind != "Skill" {
+		t.Errorf("Kind = %q", m.Kind)
+	}
+	if m.Metadata.Name != "review" {
+		t.Errorf("Name = %q", m.Metadata.Name)
+	}
+	if m.Metadata.Version != sha {
+		t.Errorf("Version = %q, want %q", m.Metadata.Version, sha)
+	}
+	if m.Spec.Entrypoint != "SKILL.md" {
+		t.Errorf("Entrypoint = %q", m.Spec.Entrypoint)
+	}
+	if len(m.Spec.Files) != 1 || m.Spec.Files[0] != "SKILL.md" {
+		t.Errorf("Files = %v", m.Spec.Files)
+	}
+	if err := artifact.Validate(m); err != nil {
+		t.Errorf("synthetic manifest should pass Validate(), got: %v", err)
+	}
+}

--- a/pkg/registry/git/git_test.go
+++ b/pkg/registry/git/git_test.go
@@ -164,20 +164,6 @@ func TestBackend_Pull_SubPath(t *testing.T) {
 	}
 }
 
-func TestBackend_Inspect_MissingManifestAtSubPath(t *testing.T) {
-	url := setupLocalRepo(t, "", "v1.0.0")
-	b := &Backend{}
-	_, err := b.Inspect(context.Background(), &artifact.GitDependency{
-		URL: url, Ref: "v1.0.0", Path: "wrong/path",
-	})
-	if err == nil {
-		t.Fatal("Inspect() should fail for wrong subpath")
-	}
-	if !strings.Contains(err.Error(), "artifact.json not found") {
-		t.Errorf("error should mention artifact.json not found: %v", err)
-	}
-}
-
 func TestBackend_Inspect_InvalidJSON(t *testing.T) {
 	dir := t.TempDir()
 	workDir := filepath.Join(dir, "work")

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -476,6 +476,29 @@ func TestResolve_VersionConflict_ParentVersionDisambiguation(t *testing.T) {
 	}
 }
 
+func TestResolve_SynthesizedManifest_VersionConflict(t *testing.T) {
+	// Two manifestless git deps with same derived name but different commits.
+	// Simulates what the resolver sees after Inspect synthesizes manifests:
+	// same name, different version (commit SHA).
+	f := &mockFetcher{manifests: map[string]*artifact.Manifest{
+		"git:https://gh.com/plugins.git@v1#skills/review!aaaa000000000000000000000000000000000000": mf("review", "aaaa000000000000000000000000000000000000"),
+		"git:https://gh.com/plugins.git@v2#skills/review!bbbb000000000000000000000000000000000000": mf("review", "bbbb000000000000000000000000000000000000"),
+	}}
+	depA := &artifact.GitDependency{URL: "https://gh.com/plugins.git", Ref: "v1", Path: "skills/review", Commit: "aaaa000000000000000000000000000000000000"}
+	depB := &artifact.GitDependency{URL: "https://gh.com/plugins.git", Ref: "v2", Path: "skills/review", Commit: "bbbb000000000000000000000000000000000000"}
+	_, err := Resolve(context.Background(), mf("root", "1.0.0", depA, depB), f)
+	if err == nil {
+		t.Fatal("want error for version conflict between two synthesized manifests")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "dependency version conflict") {
+		t.Errorf("error %q should contain 'dependency version conflict'", errMsg)
+	}
+	if !strings.Contains(errMsg, "review") {
+		t.Errorf("error should mention 'review': %v", err)
+	}
+}
+
 func TestResolve_NoConflict_SameVersionDifferentParents(t *testing.T) {
 	f := &mockFetcher{manifests: map[string]*artifact.Manifest{
 		"reg/skills/alpha:1.0.0":  mf("alpha", "1.0.0", ociDep("reg", "skills/shared", "1.0.0")),


### PR DESCRIPTION
## Summary

- Synthesize a manifest from `GitDependency` fields (`Kind`, `Entrypoint`, `Commit`, `Files`, `Name`) when the target path has no `artifact.json`. Fallback only triggers on file-not-found; malformed JSON still errors.
- Auto-collect all files under the dependency path when `Files` is omitted.
- Break `GitDependency.Validate()` into focused sub-validators (`validateGitFiles`, `validateGitName`, `validateGitEntrypoint`).
- Export `SupportedAPIVersion` const for use by the git backend.
- Split manifestless tests into `git_manifestless_test.go` to keep file sizes manageable.

Closes #83

## Test plan

- [x] 10 new `manifest_test.go` tests covering all new `Validate()` branches, serialization, and roundtrip
- [x] 13 Inspect tests for manifestless scenarios (happy path, auto-collected files, root path, custom name, missing required fields, entrypoint not in files, manifest precedence, malformed JSON, subpath with root manifest)
- [x] 10 Pull tests mirroring Inspect coverage plus synthetic manifest write, path traversal rejection, missing file
- [x] 1 resolver test for version conflict between synthesized manifests
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` reports 0 issues